### PR TITLE
Improve existing documentation for the `stark-felt` crate.

### DIFF
--- a/crates/stark-felt/src/lib.rs
+++ b/crates/stark-felt/src/lib.rs
@@ -29,7 +29,7 @@ use lambdaworks_math::{
         element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
     },
     traits::ByteConversion,
-    unsigned_integer::{element::UnsignedInteger, traits::IsUnsignedInteger},
+    unsigned_integer::element::UnsignedInteger,
 };
 
 #[cfg(feature = "arbitrary")]
@@ -286,8 +286,8 @@ impl Felt {
     /// assert_eq!(a.pow(3u32), Felt::from(27));
     /// assert_eq!(a.pow(0u32), Felt::ONE);
     /// ```
-    pub fn pow(&self, exponent: impl IsUnsignedInteger) -> Self {
-        Self(self.0.pow(exponent))
+    pub fn pow(&self, exponent: impl Into<u128>) -> Self {
+        Self(self.0.pow(exponent.into()))
     }
 
     /// Raises this [`Felt`] to the power of `exponent`.


### PR DESCRIPTION
This pull request provide some additional documentation to the methods defined for the `Felt` type.

# Important Notes

One of the examples I made for `inverse_mod` do not pass. Here is the bogus example:

```rust
use stark_felt::{Felt, NonZeroFelt};
let a = Felt::from(3);
let p = Felt::from(5).try_into().unwrap();

let b = a.inverse_mod(&p).unwrap();
assert_eq!(a.mul_mod(&b, &p), Felt::ONE);
```

This do not pass.

Apparently, `b` is computed to be `4` instead of `2`.

I'll open an issue for that.

# State

Blocked by #11 .