### PR TITLE
Impl num traits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Cargo.lock
 # Added by cargo
 
 /target
+
+*.DS_Store

--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -12,27 +12,37 @@ readme = "README.md"
 
 [dependencies]
 bitvec = { version = "1.0.1", default-features = false }
-serde = { version = "1.0.163", optional = true, default-features = false }
 lambdaworks-math = {version = "0.3.0", default-features = false}
-lambdaworks-crypto = {version = "0.3.0", default-features = false, optional = true}
-parity-scale-codec = { version = "3.2.2", default-features = false, optional = true }
 
-arbitrary = { version = "1.3.0", optional = true, default-features = false }
 num-traits = { version = "0.2.16", default-features = false }
-num-bigint = {version = "0.4.4",  default-features = false}
-num-integer = {version = "0.1.45",  default-features = false}
+num-bigint = { version = "0.4.4",  default-features = false }
+num-integer = { version = "0.1.45",  default-features = false }
 lazy_static = { version = "1.4.0", default-features = false, features = [
     "spin_no_std",
 ] }
 
+# Optional
+arbitrary = { version = "1.3.0", optional = true }
+serde = { version = "1.0.163", optional = true, default-features = false }
+lambdaworks-crypto = { version = "0.3.0", default-features = false, optional = true }
+parity-scale-codec = { version = "3.2.2", default-features = false, optional = true }
+
 [features]
-default = ["std", "serde", "curve"]
+default = ["std", "serde", "curve", "num-traits"]
+std = [
+  "bitvec/std",
+  "lambdaworks-math/std",
+  "num-traits/std",
+  "num-bigint/std",
+  "num-integer/std",
+  "serde?/std",
+]
 curve = []
 hash = ["dep:lambdaworks-crypto"]
-std = ["alloc"]
-alloc = ["serde?/alloc"]
 arbitrary = ["std", "dep:arbitrary"]
 parity-scale-codec = ["dep:parity-scale-codec"]
+serde = ["dep:serde"]
+num-traits = []
 
 [dev-dependencies]
 proptest = "1.1.0"

--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = { version = "1.4.0", default-features = false, features = [
 
 # Optional
 arbitrary = { version = "1.3.0", optional = true }
-serde = { version = "1.0.163", optional = true, default-features = false }
+serde = { version = "1.0.163", optional = true, default-features = false, features = ["alloc"] }
 lambdaworks-crypto = { version = "0.3.0", default-features = false, optional = true }
 parity-scale-codec = { version = "3.2.2", default-features = false, optional = true }
 
@@ -37,13 +37,13 @@ std = [
   "num-integer/std",
   "serde?/std",
 ]
+alloc = []
 curve = []
 hash = ["dep:lambdaworks-crypto"]
 arbitrary = ["std", "dep:arbitrary"]
 parity-scale-codec = ["dep:parity-scale-codec"]
-serde = ["dep:serde"]
+serde = ["alloc", "dep:serde"]
 num-traits = []
-alloc = ["serde?/alloc"]
 
 [dev-dependencies]
 proptest = "1.1.0"

--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -43,6 +43,7 @@ arbitrary = ["std", "dep:arbitrary"]
 parity-scale-codec = ["dep:parity-scale-codec"]
 serde = ["dep:serde"]
 num-traits = []
+alloc = ["serde?/alloc"]
 
 [dev-dependencies]
 proptest = "1.1.0"

--- a/crates/starknet-types-core/src/felt/felt_arbitrary.rs
+++ b/crates/starknet-types-core/src/felt/felt_arbitrary.rs
@@ -1,5 +1,4 @@
 use lambdaworks_math::{field::element::FieldElement, unsigned_integer::element::UnsignedInteger};
-use num_traits::Zero;
 use proptest::prelude::*;
 
 use crate::felt::Felt;
@@ -37,7 +36,7 @@ fn any_felt() -> impl Strategy<Value = Felt> {
 /// Returns a [`Strategy`] that generates any nonzero Felt
 /// This is used to generate input values for proptests
 pub fn nonzero_felt() -> impl Strategy<Value = Felt> {
-    any_felt().prop_filter("is zero", |x| !x.is_zero())
+    any_felt().prop_filter("is zero", |&x| x != Felt::ZERO)
 }
 
 impl Arbitrary for Felt {

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -980,8 +980,8 @@ mod errors {
 #[cfg(test)]
 mod test {
     use super::alloc::{format, string::String, vec::Vec};
+    use super::felt_arbitrary::nonzero_felt;
     use super::*;
-    use crate::felt_arbitrary::nonzero_felt;
     use core::ops::Shl;
     use proptest::prelude::*;
     #[cfg(feature = "serde")]

--- a/crates/starknet-types-core/src/felt/num_traits_impl.rs
+++ b/crates/starknet-types-core/src/felt/num_traits_impl.rs
@@ -1,0 +1,123 @@
+use super::Felt;
+use num_traits::{FromPrimitive, Inv, One, Pow, ToPrimitive, Zero};
+
+impl FromPrimitive for Felt {
+    fn from_i64(value: i64) -> Option<Self> {
+        Some(value.into())
+    }
+
+    fn from_u64(value: u64) -> Option<Self> {
+        Some(value.into())
+    }
+
+    fn from_i128(value: i128) -> Option<Self> {
+        Some(value.into())
+    }
+
+    fn from_u128(value: u128) -> Option<Self> {
+        Some(value.into())
+    }
+}
+
+// TODO: we need to decide whether we want conversions to signed primitives
+// will support converting the high end of the field to negative.
+impl ToPrimitive for Felt {
+    fn to_u64(&self) -> Option<u64> {
+        self.to_u128().and_then(|x| u64::try_from(x).ok())
+    }
+
+    fn to_i64(&self) -> Option<i64> {
+        self.to_u128().and_then(|x| i64::try_from(x).ok())
+    }
+
+    fn to_u128(&self) -> Option<u128> {
+        match self.0.representative().limbs {
+            [0, 0, hi, lo] => Some((lo as u128) | ((hi as u128) << 64)),
+            _ => None,
+        }
+    }
+
+    fn to_i128(&self) -> Option<i128> {
+        self.to_u128().and_then(|x| i128::try_from(x).ok())
+    }
+}
+
+impl Zero for Felt {
+    fn is_zero(&self) -> bool {
+        *self == Felt::ZERO
+    }
+
+    fn zero() -> Felt {
+        Felt::ZERO
+    }
+}
+
+impl One for Felt {
+    fn one() -> Self {
+        Felt::ONE
+    }
+}
+
+impl Inv for Felt {
+    type Output = Option<Self>;
+
+    fn inv(self) -> Self::Output {
+        self.inverse()
+    }
+}
+
+impl Pow<u8> for Felt {
+    type Output = Self;
+
+    fn pow(self, rhs: u8) -> Self::Output {
+        Self(self.0.pow(rhs as u128))
+    }
+}
+impl Pow<u16> for Felt {
+    type Output = Self;
+
+    fn pow(self, rhs: u16) -> Self::Output {
+        Self(self.0.pow(rhs as u128))
+    }
+}
+impl Pow<u32> for Felt {
+    type Output = Self;
+
+    fn pow(self, rhs: u32) -> Self::Output {
+        Self(self.0.pow(rhs as u128))
+    }
+}
+impl Pow<u64> for Felt {
+    type Output = Self;
+
+    fn pow(self, rhs: u64) -> Self::Output {
+        Self(self.0.pow(rhs as u128))
+    }
+}
+impl Pow<u128> for Felt {
+    type Output = Self;
+
+    fn pow(self, rhs: u128) -> Self::Output {
+        Self(self.0.pow(rhs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_is_zero() {
+        assert!(Felt::ZERO.is_zero());
+    }
+
+    #[test]
+    fn one_is_one() {
+        assert!(Felt::ONE.is_one());
+    }
+
+    #[test]
+    fn default_is_zero() {
+        assert!(Felt::default().is_zero());
+    }
+}

--- a/crates/starknet-types-core/src/lib.rs
+++ b/crates/starknet-types-core/src/lib.rs
@@ -5,5 +5,3 @@ pub mod curve;
 pub mod hash;
 
 pub mod felt;
-#[cfg(test)]
-mod felt_arbitrary;

--- a/crates/starknet-types-rpc/Cargo.toml
+++ b/crates/starknet-types-rpc/Cargo.toml
@@ -16,7 +16,7 @@ default = ["std"]
 std = ["serde/std", "starknet-types-core/std"]
 
 [dependencies]
-starknet-types-core = { path = "../starknet-types-core", default-features = false, features = ["serde", "alloc"] }
+starknet-types-core = { path = "../starknet-types-core", default-features = false, features = ["serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/starknet-types-rpc/Cargo.toml
+++ b/crates/starknet-types-rpc/Cargo.toml
@@ -16,7 +16,7 @@ default = ["std"]
 std = ["serde/std", "starknet-types-core/std"]
 
 [dependencies]
-starknet-types-core = { path = "../starknet-types-core", default-features = false, features = ["serde"] }
+starknet-types-core = { path = "../starknet-types-core", default-features = false, features = ["serde", "alloc"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/ensure_no_std/Cargo.toml
+++ b/ensure_no_std/Cargo.toml
@@ -9,6 +9,7 @@ starknet-types-core = { path = "../crates/starknet-types-core", default-features
     "serde",
     "curve",
     "parity-scale-codec",
+    "num-traits",
 ] }
 starknet-types-rpc = { path = "../crates/starknet-types-rpc", default-features = false }
 wee_alloc = "0.4.5"

--- a/ensure_no_std/src/main.rs
+++ b/ensure_no_std/src/main.rs
@@ -19,3 +19,5 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[allow(unused_imports)]
 use starknet_types_core;
+#[allow(unused_imports)]
+use starknet_types_rpc;


### PR DESCRIPTION
resolves #7 

## What is the new behavior?

`num_traits::{Inv, Pow, One, Zero}` are implemented on `Felt`
They exist behind a feature flag. So if you don't need them, you can build the crate without.

## Does this introduce a breaking change?

No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
