### PR TITLE
Update lambdaworks version to 0.3.0

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 [dependencies]
 bitvec = { version = "1.0.1", default-features = false }
 serde = { version = "1.0.163", optional = true, default-features = false }
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks.git", rev = "f940e14ed17370d29fe129951448037d11b65ce8", default-features = false}
-lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks.git", rev = "f940e14ed17370d29fe129951448037d11b65ce8", default-features = false, optional = true}
+lambdaworks-math = {version = "0.3.0", default-features = false}
+lambdaworks-crypto = {version = "0.3.0", default-features = false, optional = true}
 
 
 arbitrary = { version = "1.3.0", optional = true, default-features = false }


### PR DESCRIPTION
# Update lambdaworks version to 0.3.0

## Does this introduce a breaking change?

No

After merging this PR it will be good to make a types-rs crate release so we can stark using types-rs in the cairo-vm #[1408](https://github.com/lambdaclass/cairo-vm/pull/1408)