### PR TITLE
Implement felt to bigint functions

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -21,6 +21,7 @@ arbitrary = { version = "1.3.0", optional = true, default-features = false }
 num-traits = { version = "0.2.16", default-features = false }
 num-bigint = {version = "0.4.4",  default-features = false}
 num-integer = {version = "0.1.45",  default-features = false}
+lazy_static = { version = "1.4.0", default-features = false }
 
 [features]
 default = ["std", "serde", "curve"]

--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -21,7 +21,9 @@ arbitrary = { version = "1.3.0", optional = true, default-features = false }
 num-traits = { version = "0.2.16", default-features = false }
 num-bigint = {version = "0.4.4",  default-features = false}
 num-integer = {version = "0.1.45",  default-features = false}
-lazy_static = { version = "1.4.0", default-features = false }
+lazy_static = { version = "1.4.0", default-features = false, features = [
+    "spin_no_std",
+] }
 
 [features]
 default = ["std", "serde", "curve"]

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -456,6 +456,12 @@ impl From<&BigInt> for Felt {
     }
 }
 
+impl From<&BigUint> for Felt {
+    fn from(biguint: &BigUint) -> Felt {
+        Felt::from_bytes_le_slice(&biguint.to_bytes_le())
+    }
+}
+
 macro_rules! impl_from {
     ($from:ty, $with:ty) => {
         impl From<$from> for Felt {
@@ -829,10 +835,6 @@ pub fn felt_to_biguint(felt: Felt) -> BigUint {
 
 pub fn felt_to_bigint(felt: Felt) -> BigInt {
     felt_to_biguint(felt).to_bigint().unwrap()
-}
-
-pub fn biguint_to_felt(biguint: &BigUint) -> Felt {
-    Felt::from_bytes_le_slice(&biguint.to_bytes_le())
 }
 
 #[cfg(feature = "serde")]
@@ -1643,11 +1645,11 @@ mod test {
     #[test]
     fn bigints_to_felt() {
         let one = &*CAIRO_PRIME_BIGINT + BigInt::from(1_u32);
-        assert_eq!(biguint_to_felt(&one.to_biguint().unwrap()), Felt::from(1));
+        assert_eq!(Felt::from(&one.to_biguint().unwrap()), Felt::from(1));
         assert_eq!(Felt::from(&one), Felt::from(1));
 
         let zero = &*CAIRO_PRIME_BIGINT * 99_u32;
-        assert_eq!(biguint_to_felt(&zero.to_biguint().unwrap()), Felt::from(0));
+        assert_eq!(Felt::from(&zero.to_biguint().unwrap()), Felt::from(0));
         assert_eq!(Felt::from(&zero), Felt::from(0));
 
         assert_eq!(
@@ -1671,7 +1673,7 @@ mod test {
                 Felt::from_hex(number_str).unwrap()
             );
             assert_eq!(
-                biguint_to_felt(&BigUint::from_str_radix(&number_str[2..], 16).unwrap()),
+                Felt::from(&BigUint::from_str_radix(&number_str[2..], 16).unwrap()),
                 Felt::from_hex(number_str).unwrap()
             )
         }

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -356,6 +356,15 @@ impl Felt {
     pub fn bits(&self) -> usize {
         self.0.representative().bits_le()
     }
+
+    pub fn to_biguint(&self) -> BigUint {
+        let big_digits = self
+            .to_le_digits()
+            .into_iter()
+            .flat_map(|limb| [limb as u32, (limb >> 32) as u32])
+            .collect();
+        BigUint::new(big_digits)
+    }
 }
 
 #[cfg(feature = "arbitrary")]
@@ -824,17 +833,8 @@ mod arithmetic {
     }
 }
 
-pub fn felt_to_biguint(felt: Felt) -> BigUint {
-    let big_digits = felt
-        .to_le_digits()
-        .into_iter()
-        .flat_map(|limb| [limb as u32, (limb >> 32) as u32])
-        .collect();
-    BigUint::new(big_digits)
-}
-
 pub fn felt_to_bigint(felt: Felt) -> BigInt {
-    felt_to_biguint(felt).to_bigint().unwrap()
+    felt.to_biguint().to_bigint().unwrap()
 }
 
 #[cfg(feature = "serde")]
@@ -1697,7 +1697,7 @@ mod test {
             );
 
             assert_eq!(
-                felt_to_biguint(Felt::from_hex(number_str).unwrap()),
+                Felt::from_hex(number_str).unwrap().to_biguint(),
                 BigUint::from_str_radix(&number_str[2..], 16).unwrap()
             );
         }

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -365,6 +365,10 @@ impl Felt {
             .collect();
         BigUint::new(big_digits)
     }
+
+    pub fn to_bigint(&self) -> BigInt {
+        self.to_biguint().to_bigint().unwrap()
+    }
 }
 
 #[cfg(feature = "arbitrary")]
@@ -831,10 +835,6 @@ mod arithmetic {
             base
         }
     }
-}
-
-pub fn felt_to_bigint(felt: Felt) -> BigInt {
-    felt.to_biguint().to_bigint().unwrap()
 }
 
 #[cfg(feature = "serde")]
@@ -1692,7 +1692,7 @@ mod test {
 
         for number_str in numbers_str {
             assert_eq!(
-                felt_to_bigint(Felt::from_hex(number_str).unwrap()),
+                Felt::from_hex(number_str).unwrap().to_bigint(),
                 BigInt::from_str_radix(&number_str[2..], 16).unwrap()
             );
 

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -2,7 +2,7 @@ use core::ops::{Add, Mul, Neg};
 
 use bitvec::array::BitArray;
 use lazy_static::lazy_static;
-use num_bigint::{BigInt, BigUint, Sign, ToBigInt};
+use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
 use num_traits::Num;
 use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
@@ -367,7 +367,7 @@ impl Felt {
     }
 
     pub fn to_bigint(&self) -> BigInt {
-        self.to_biguint().to_bigint().unwrap()
+        self.to_biguint().into()
     }
 }
 

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -1,9 +1,19 @@
 use core::ops::{Add, Mul, Neg};
 
 use bitvec::array::BitArray;
-use num_bigint::BigInt;
+use lazy_static::lazy_static;
+use num_bigint::{BigInt, BigUint, Sign, ToBigInt};
 use num_integer::Integer;
+use num_traits::Num;
 use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
+
+lazy_static! {
+    pub static ref CAIRO_PRIME_BIGINT: BigInt = BigInt::from_str_radix(
+        "800000000000011000000000000000000000000000000000000000000000001",
+        16
+    )
+    .unwrap();
+}
 
 #[cfg(target_pointer_width = "64")]
 pub type BitArrayStore = [u64; 4];
@@ -796,6 +806,33 @@ mod arithmetic {
     }
 }
 
+pub fn felt_to_biguint(felt: Felt) -> BigUint {
+    let big_digits = felt
+        .to_le_digits()
+        .into_iter()
+        .flat_map(|limb| [limb as u32, (limb >> 32) as u32])
+        .collect();
+    BigUint::new(big_digits)
+}
+
+pub fn felt_to_bigint(felt: Felt) -> BigInt {
+    felt_to_biguint(felt).to_bigint().unwrap()
+}
+
+pub fn biguint_to_felt(biguint: &BigUint) -> Felt {
+    Felt::from_bytes_le_slice(&biguint.to_bytes_le())
+}
+
+pub fn bigint_to_felt(bigint: &BigInt) -> Felt {
+    let (sign, bytes) = bigint.mod_floor(&CAIRO_PRIME_BIGINT).to_bytes_le();
+    let felt = Felt::from_bytes_le_slice(&bytes);
+    if sign == Sign::Minus {
+        felt.neg()
+    } else {
+        felt
+    }
+}
+
 #[cfg(feature = "serde")]
 mod serde {
     use ::serde::{de, ser::SerializeSeq, Deserialize, Serialize};
@@ -945,47 +982,6 @@ mod errors {
     }
 }
 
-pub mod bigints {
-    use lazy_static::lazy_static;
-    use num_bigint::{BigUint, Sign, ToBigInt};
-    use num_traits::Num;
-
-    use super::*;
-    lazy_static! {
-        pub static ref CAIRO_PRIME_BIGINT: BigInt = BigInt::from_str_radix(
-            "800000000000011000000000000000000000000000000000000000000000001",
-            16
-        )
-        .unwrap();
-    }
-
-    pub fn felt_to_biguint(felt: Felt) -> BigUint {
-        let big_digits = felt
-            .to_le_digits()
-            .into_iter()
-            .flat_map(|limb| [limb as u32, (limb >> 32) as u32])
-            .collect();
-        BigUint::new(big_digits)
-    }
-
-    pub fn felt_to_bigint(felt: Felt) -> BigInt {
-        felt_to_biguint(felt).to_bigint().unwrap()
-    }
-
-    pub fn biguint_to_felt(biguint: &BigUint) -> Felt {
-        Felt::from_bytes_le_slice(&biguint.to_bytes_le())
-    }
-
-    pub fn bigint_to_felt(bigint: &BigInt) -> Felt {
-        let (sign, bytes) = bigint.mod_floor(&CAIRO_PRIME_BIGINT).to_bytes_le();
-        let felt = Felt::from_bytes_le_slice(&bytes);
-        if sign == Sign::Minus {
-            felt.neg()
-        } else {
-            felt
-        }
-    }
-}
 #[cfg(test)]
 mod test {
     use super::alloc::{format, string::String, vec::Vec};

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -945,6 +945,47 @@ mod errors {
     }
 }
 
+pub mod bigints {
+    use lazy_static::lazy_static;
+    use num_bigint::{BigUint, Sign, ToBigInt};
+    use num_traits::Num;
+
+    use super::*;
+    lazy_static! {
+        pub static ref CAIRO_PRIME_BIGINT: BigInt = BigInt::from_str_radix(
+            "800000000000011000000000000000000000000000000000000000000000001",
+            16
+        )
+        .unwrap();
+    }
+
+    pub fn felt_to_biguint(felt: Felt) -> BigUint {
+        let big_digits = felt
+            .to_le_digits()
+            .into_iter()
+            .flat_map(|limb| [limb as u32, (limb >> 32) as u32])
+            .collect();
+        BigUint::new(big_digits)
+    }
+
+    pub fn felt_to_bigint(felt: Felt) -> BigInt {
+        felt_to_biguint(felt).to_bigint().unwrap()
+    }
+
+    pub fn biguint_to_felt(biguint: &BigUint) -> Felt {
+        Felt::from_bytes_le_slice(&biguint.to_bytes_le())
+    }
+
+    pub fn bigint_to_felt(bigint: &BigInt) -> Felt {
+        let (sign, bytes) = bigint.mod_floor(&CAIRO_PRIME_BIGINT).to_bytes_le();
+        let felt = Felt::from_bytes_le_slice(&bytes);
+        if sign == Sign::Minus {
+            felt.neg()
+        } else {
+            felt
+        }
+    }
+}
 #[cfg(test)]
 mod test {
     use super::alloc::{format, string::String, vec::Vec};

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -1637,4 +1637,65 @@ mod test {
 
         assert_eq!(x.mul_mod(&y, &p), expected_result);
     }
+
+    #[test]
+    fn bigints_to_felt() {
+        let one = &*CAIRO_PRIME_BIGINT + BigInt::from(1_u32);
+        assert_eq!(biguint_to_felt(&one.to_biguint().unwrap()), Felt::from(1));
+        assert_eq!(bigint_to_felt(&one), Felt::from(1));
+
+        let zero = &*CAIRO_PRIME_BIGINT * 99_u32;
+        assert_eq!(biguint_to_felt(&zero.to_biguint().unwrap()), Felt::from(0));
+        assert_eq!(bigint_to_felt(&zero), Felt::from(0));
+
+        assert_eq!(
+            bigint_to_felt(&BigInt::from(-1)),
+            Felt::from_hex("0x800000000000011000000000000000000000000000000000000000000000000")
+                .unwrap()
+        );
+
+        let numbers_str = [
+            "0x0",
+            "0x1",
+            "0x10",
+            "0x8000000000000110000000000",
+            "0xffffffffffffff",
+            "0xffffffffefff12380777abcd",
+        ];
+
+        for number_str in numbers_str {
+            assert_eq!(
+                bigint_to_felt(&BigInt::from_str_radix(&number_str[2..], 16).unwrap()),
+                Felt::from_hex(number_str).unwrap()
+            );
+            assert_eq!(
+                biguint_to_felt(&BigUint::from_str_radix(&number_str[2..], 16).unwrap()),
+                Felt::from_hex(number_str).unwrap()
+            )
+        }
+    }
+
+    #[test]
+    fn felt_to_bigints() {
+        let numbers_str = [
+            "0x0",
+            "0x1",
+            "0x10",
+            "0x8000000000000110000000000",
+            "0xffffffffffffff",
+            "0xffffffffefff12380777abcd",
+        ];
+
+        for number_str in numbers_str {
+            assert_eq!(
+                felt_to_bigint(Felt::from_hex(number_str).unwrap()),
+                BigInt::from_str_radix(&number_str[2..], 16).unwrap()
+            );
+
+            assert_eq!(
+                felt_to_biguint(Felt::from_hex(number_str).unwrap()),
+                BigUint::from_str_radix(&number_str[2..], 16).unwrap()
+            );
+        }
+    }
 }


### PR DESCRIPTION
# Implement felt to bigint functions
Since various crates have to work with BigInts and BigUints operations, here we implement some Felt to BigInt and Biguint conversions.
* pub fn felt_to_biguint(felt: Felt) -> BigUint
* pub fn felt_to_bigint(felt: Felt) -> BigInt
* pub fn biguint_to_felt(biguint: &BigUint) -> Felt
* pub fn bigint_to_felt(bigint: &BigInt) -> Felt

## Does this introduce a breaking change?

No
