### PR TITLE
feat: hex formatting helper

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -26,7 +26,7 @@ num-integer = {version = "0.1.45",  default-features = false}
 default = ["std", "serde", "curve"]
 curve = []
 hash = ["dep:lambdaworks-crypto"]
-std = []
+std = ["alloc"]
 alloc = ["serde?/alloc"]
 arbitrary = ["std", "dep:arbitrary"]
 

--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -26,7 +26,7 @@ num-integer = {version = "0.1.45",  default-features = false}
 default = ["std", "serde", "curve"]
 curve = []
 hash = ["dep:lambdaworks-crypto"]
-std = ["alloc"]
+std = []
 alloc = ["serde?/alloc"]
 arbitrary = ["std", "dep:arbitrary"]
 

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -200,6 +200,12 @@ impl Felt {
         BitArray::new(limbs)
     }
 
+    /// Helper to produce a hexadecimal formatted string.
+    /// Equivalent to calling `format!("{self:#x}")`.
+    pub fn to_hex_string(&self) -> String {
+        format!("{self:#x}")
+    }
+
     /// Converts to little-endian bit representation.
     /// This is as performant as [to_bits_be](Felt::to_bits_be)
     pub fn to_bits_le(&self) -> BitArray<BitArrayStore> {
@@ -1017,6 +1023,11 @@ mod test {
             }
             let y = &Felt::from_bytes_le(&bytes);
             prop_assert_eq!(x, y);
+        }
+
+        #[test]
+        fn to_hex_string_is_same_as_format(ref x in any::<Felt>()) {
+            prop_assert_eq!(format!("{x:#x}"), x.to_hex_string());
         }
 
         #[test]

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -1029,7 +1029,7 @@ mod test {
         #[test]
         #[cfg(feature = "alloc")]
         fn to_hex_string_is_same_as_format(ref x in any::<Felt>()) {
-            prop_assert_eq!(std::format!("{x:#x}"), x.to_hex_string());
+            prop_assert_eq!(alloc::format!("{x:#x}"), x.to_hex_string());
         }
 
         #[test]

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -202,8 +202,9 @@ impl Felt {
 
     /// Helper to produce a hexadecimal formatted string.
     /// Equivalent to calling `format!("{self:#x}")`.
-    pub fn to_hex_string(&self) -> String {
-        format!("{self:#x}")
+    #[cfg(feature = "alloc")]
+    pub fn to_hex_string(&self) -> alloc::string::String {
+        alloc::format!("{self:#x}")
     }
 
     /// Converts to little-endian bit representation.
@@ -1026,8 +1027,9 @@ mod test {
         }
 
         #[test]
+        #[cfg(feature = "alloc")]
         fn to_hex_string_is_same_as_format(ref x in any::<Felt>()) {
-            prop_assert_eq!(format!("{x:#x}"), x.to_hex_string());
+            prop_assert_eq!(std::format!("{x:#x}"), x.to_hex_string());
         }
 
         #[test]


### PR DESCRIPTION
Little helper to format felts as hex strings with prefix notation. Because the method returns a `String`, the `alloc` features is required.

# Pull Request type

- Feature

## Does this introduce a breaking change?

Yes
