### PR TITLE
fix: std requires alloc

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -26,7 +26,7 @@ num-integer = {version = "0.1.45",  default-features = false}
 default = ["std", "serde", "curve"]
 curve = []
 hash = ["dep:lambdaworks-crypto"]
-std = []
+std = ["alloc"]
 alloc = ["serde?/alloc"]
 arbitrary = ["std", "dep:arbitrary"]
 


### PR DESCRIPTION
The Rust standard library already requires a global allocator. This means all features that only depend on that should be usable when `std` is enabled, so let's make that implication explicit in our manifest.

# Pull Request type

- Bugfix

## What is the current behavior?

You need to explicitly enable `alloc` even if you're building with `std`.

## What is the new behavior?

Enabling `std` always enables `alloc`.

## Does this introduce a breaking change?

Technically, yes. You can no longer trigger a build with `std` but no global allocator. In practice, no, those builds were already broken.
