### PR TITLE
Add parity-scale-codec serialization for Felts

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -15,7 +15,7 @@ bitvec = { version = "1.0.1", default-features = false }
 serde = { version = "1.0.163", optional = true, default-features = false }
 lambdaworks-math = {version = "0.3.0", default-features = false}
 lambdaworks-crypto = {version = "0.3.0", default-features = false, optional = true}
-
+parity-scale-codec = { version = "3.2.2", default-features = false, optional = true }
 
 arbitrary = { version = "1.3.0", optional = true, default-features = false }
 num-traits = { version = "0.2.16", default-features = false }
@@ -32,6 +32,7 @@ hash = ["dep:lambdaworks-crypto"]
 std = ["alloc"]
 alloc = ["serde?/alloc"]
 arbitrary = ["std", "dep:arbitrary"]
+parity-scale-codec = ["dep:parity-scale-codec"]
 
 [dev-dependencies]
 proptest = "1.1.0"

--- a/crates/starknet-types-core/README.md
+++ b/crates/starknet-types-core/README.md
@@ -17,6 +17,10 @@ The `starknet-types-core` crate provides:
 - Provides a Serialization and Deserialization implementations for the `Felt` type
 - No_std support ✅
 
+### Parity Scale Codec
+- Provides Serialization and Deserialization implementations for the `Felt` type within the Parity serialization framework
+- No_std support ✅
+
 ### Arbitrary
 - Provides an Arbitrary implementations for the `Felt` type
 

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -1760,11 +1760,10 @@ mod test {
         use parity_scale_codec::{Decode, Encode};
 
         // use an endianness-asymetric number to test that byte order is correct in serialization
-        let initial_felt: Felt = Felt::from_hex("0xabcdef123").unwrap().try_into().unwrap();
+        let initial_felt = Felt::from_hex("0xabcdef123").unwrap();
 
         // serialize the felt
-        let mut serialized_felt = Vec::new();
-        initial_felt.encode_to(&mut serialized_felt);
+        let serialized_felt = initial_felt.encode();
 
         // deserialize the felt
         let deserialized_felt = Felt::decode(&mut &serialized_felt[..]).unwrap();

--- a/crates/starknet-types-core/src/felt.rs
+++ b/crates/starknet-types-core/src/felt.rs
@@ -391,6 +391,26 @@ impl<'a> Arbitrary<'a> for Felt {
     }
 }
 
+/// Allows transparent binary serialization of Felts with `parity_scale_codec`.
+#[cfg(feature = "parity-scale-codec")]
+impl parity_scale_codec::Encode for Felt {
+    fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {
+        dest.write(&self.to_bytes_be());
+    }
+}
+
+/// Allows transparent binary deserialization of Felts with `parity_scale_codec`
+#[cfg(feature = "parity-scale-codec")]
+impl parity_scale_codec::Decode for Felt {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        let mut buf: [u8; 32] = [0; 32];
+        input.read(&mut buf)?;
+        Ok(Felt::from_bytes_be(&buf))
+    }
+}
+
 /// Defaults to [Felt::ZERO].
 impl Default for Felt {
     fn default() -> Self {
@@ -1731,5 +1751,28 @@ mod test {
         let one: Felt = true.into();
         assert_eq!(one, Felt::ONE);
         assert_eq!(zero, Felt::ZERO);
+    }
+
+    /// Tests proper serialization and deserialization of felts using `parity-scale-codec`.
+    #[test]
+    #[cfg(feature = "parity-scale-codec")]
+    fn parity_scale_codec_serialization() {
+        use parity_scale_codec::{Decode, Encode};
+
+        // use an endianness-asymetric number to test that byte order is correct in serialization
+        let initial_felt: Felt = Felt::from_hex("0xabcdef123").unwrap().try_into().unwrap();
+
+        // serialize the felt
+        let mut serialized_felt = Vec::new();
+        initial_felt.encode_to(&mut serialized_felt);
+
+        // deserialize the felt
+        let deserialized_felt = Felt::decode(&mut &serialized_felt[..]).unwrap();
+
+        // check that the deserialized felt is the same as the initial one
+        assert_eq!(
+            initial_felt, deserialized_felt,
+            "mismatch between original and deserialized felts"
+        );
     }
 }

--- a/ensure_no_std/Cargo.toml
+++ b/ensure_no_std/Cargo.toml
@@ -8,6 +8,7 @@ starknet-types-core = { path = "../crates/starknet-types-core", default-features
     "alloc",
     "serde",
     "curve",
+    "parity-scale-codec",
 ] }
 starknet-types-rpc = { path = "../crates/starknet-types-rpc", default-features = false }
 wee_alloc = "0.4.5"


### PR DESCRIPTION
Adds parity-scale-codec binary serialization and de-serialization for Felts under the parity-scale-codec feature flag.

# Pull Request type

- Feature

## What is the current behavior?

Currently, there is no support for the parity-scale-codec serialization framework. 

## What is the new behavior?

This PR enabled transparent support for parity-scale-codec binary  (de-)serialization of Felts when the parity-scale-codec feature flag is enabled. 

## Does this introduce a breaking change?

No, the parity-scale-codec flag is disabled by default.


