### PR TITLE
Add double implementation for Felt

### DIFF
--- a/crates/starknet-types-core/proptest-regressions/felt/mod.txt
+++ b/crates/starknet-types-core/proptest-regressions/felt/mod.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 7cc7e05316cf3a4fc6fc302a9d0addd5ec76e6cd733ef30c109c14be6d0bf9d5 # shrinks to x = Felt(FieldElement { value: UnsignedInteger { limbs: [300729720636178304, 1831347307108920996, 11337269826263459472, 8939133563709308857] } })

--- a/crates/starknet-types-core/proptest-regressions/felt/mod.txt
+++ b/crates/starknet-types-core/proptest-regressions/felt/mod.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 7cc7e05316cf3a4fc6fc302a9d0addd5ec76e6cd733ef30c109c14be6d0bf9d5 # shrinks to x = Felt(FieldElement { value: UnsignedInteger { limbs: [300729720636178304, 1831347307108920996, 11337269826263459472, 8939133563709308857] } })

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -360,6 +360,11 @@ impl Felt {
         Self(self.0.square())
     }
 
+    /// Doubles the point `self`
+    pub fn double(&self) -> Self {
+        Self(self.0.add(self.0))
+    }
+
     /// Raises `self` to the power of `exponent`.
     pub fn pow(&self, exponent: impl Into<u128>) -> Self {
         Self(self.0.pow(exponent.into()))
@@ -1304,6 +1309,11 @@ mod test {
         }
 
         #[test]
+        fn double_in_range(x in any::<Felt>()) {
+            prop_assert!(x.double() == x + x);
+        }
+
+         #[test]
         fn square_in_range(x in any::<Felt>()) {
             prop_assert!(x.square() <= Felt::MAX);
         }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Add double implementation for Felt

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- This pull request introduces a utility method `double` for the `Felt` type. The `double` method allows for more convenient and concise code when needing to double a `Felt` value. Previously, one would have to write `x + x` to achieve the same result, which can be verbose and less readable. With the addition of `double`, users can now simply call `x.double()` to achieve the same outcome.

## Does this introduce a breaking change?

No

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
