### PR TITLE
Add Pedersen benchmark

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -26,6 +26,9 @@ arbitrary = { version = "1.3.0", optional = true }
 serde = { version = "1.0.163", optional = true, default-features = false, features = ["alloc"] }
 lambdaworks-crypto = { version = "0.5.0", default-features = false, optional = true }
 parity-scale-codec = { version = "3.2.2", default-features = false, optional = true }
+criterion = "0.5.1"
+rand_chacha = "0.3.1"
+rand = "0.8.5"
 
 [features]
 default = ["std", "serde", "curve", "num-traits"]
@@ -51,3 +54,7 @@ papyrus-serialization = []
 proptest = "1.1.0"
 regex = "1.10.3"
 serde_test = "1.0.1"
+
+[[bench]]
+name= "criterion_pedersen"
+harness=false

--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -26,9 +26,6 @@ arbitrary = { version = "1.3.0", optional = true }
 serde = { version = "1.0.163", optional = true, default-features = false, features = ["alloc"] }
 lambdaworks-crypto = { version = "0.5.0", default-features = false, optional = true }
 parity-scale-codec = { version = "3.2.2", default-features = false, optional = true }
-criterion = "0.5.1"
-rand_chacha = "0.3.1"
-rand = "0.8.5"
 
 [features]
 default = ["std", "serde", "curve", "num-traits"]
@@ -54,6 +51,9 @@ papyrus-serialization = []
 proptest = "1.1.0"
 regex = "1.10.3"
 serde_test = "1.0.1"
+criterion = "0.5.1"
+rand_chacha = "0.3.1"
+rand = "0.8.5"
 
 [[bench]]
 name= "criterion_pedersen"

--- a/crates/starknet-types-core/Makefile
+++ b/crates/starknet-types-core/Makefile
@@ -1,0 +1,10 @@
+.PHONY: build test bench
+
+build:
+	cargo build --release
+
+test:
+	cargo test 
+
+bench:
+	cargo bench --bench criterion_pedersen --features hash

--- a/crates/starknet-types-core/benches/criterion_pedersen.rs
+++ b/crates/starknet-types-core/benches/criterion_pedersen.rs
@@ -1,0 +1,26 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use starknet_types_core::felt::Felt;
+use starknet_types_core::hash::Pedersen;
+use starknet_types_core::hash::StarkHash;
+
+fn pedersen_benchmarks(c: &mut Criterion) {
+    let mut rng = ChaCha8Rng::seed_from_u64(2);
+    let mut felt1: [u8; 32] = Default::default();
+    rng.fill_bytes(&mut felt1);
+    let mut felt2: [u8; 32] = Default::default();
+    rng.fill_bytes(&mut felt2);
+
+    let x = Felt::from_bytes_be(&felt1);
+    let y = Felt::from_bytes_be(&felt2);
+    let mut group = c.benchmark_group("Pedersen Benchmark");
+    // let pedersen = black_box(Pedersen::default());
+
+    // Benchmark with black_box is 0.41% faster
+    group.bench_function("Hashing with black_box", |bench| {
+        bench.iter(|| black_box(Pedersen::hash(&x, &y)))
+    });
+}
+criterion_group!(pedersen, pedersen_benchmarks);
+criterion_main!(pedersen);

--- a/crates/starknet-types-core/benches/criterion_pedersen.rs
+++ b/crates/starknet-types-core/benches/criterion_pedersen.rs
@@ -15,9 +15,7 @@ fn pedersen_benchmarks(c: &mut Criterion) {
     let x = Felt::from_bytes_be(&felt1);
     let y = Felt::from_bytes_be(&felt2);
     let mut group = c.benchmark_group("Pedersen Benchmark");
-    // let pedersen = black_box(Pedersen::default());
 
-    // Benchmark with black_box is 0.41% faster
     group.bench_function("Hashing with black_box", |bench| {
         bench.iter(|| black_box(Pedersen::hash(&x, &y)))
     });

--- a/ensure_no_std/rust-toolchain.toml
+++ b/ensure_no_std/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-02-26"
+channel = "1.74"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.72"
+channel = "1.74"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
# Add Perdersen benchmark
* Add a criterion benchmark that runs the Pedesen::Hash function
* Add a little Makefile to the starknet-core-types crate
* Update Rust toolchain to 1.74.0 in `starknet-types-core` and `ensure_no_std` crates


## Does this introduce a breaking change?
No
