### PR TITLE
perf: update lambdaworks to 0.6.0

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 bitvec = { version = "1.0.1", default-features = false }
-lambdaworks-math = { version = "0.5.0", default-features = false}
+lambdaworks-math = { version = "0.6.0", default-features = false}
 
 num-traits = { version = "0.2.16", default-features = false }
 num-bigint = { version = "0.4.4",  default-features = false }
@@ -24,7 +24,7 @@ lazy_static = { version = "1.4.0", default-features = false, features = [
 # Optional
 arbitrary = { version = "1.3.0", optional = true }
 serde = { version = "1.0.163", optional = true, default-features = false, features = ["alloc"] }
-lambdaworks-crypto = { version = "0.5.0", default-features = false, optional = true }
+lambdaworks-crypto = { version = "0.6.0", default-features = false, optional = true }
 parity-scale-codec = { version = "3.2.2", default-features = false, optional = true }
 
 [features]

--- a/crates/starknet-types-core/src/hash/pedersen.rs
+++ b/crates/starknet-types-core/src/hash/pedersen.rs
@@ -1,34 +1,30 @@
 use crate::felt::Felt;
-use lambdaworks_crypto::hash::pedersen::Pedersen as PedersenLambdaworks;
+use lambdaworks_crypto::hash::pedersen::{Pedersen as PedersenLambdaworks, PedersenStarkCurve};
 use lambdaworks_math::field::{
     element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
 };
-use lazy_static::lazy_static;
 
 use super::traits::StarkHash;
 
 pub struct Pedersen;
 
-lazy_static! {
-    /// Pedersen hasher.
-    pub static ref PEDERSEN: PedersenLambdaworks = PedersenLambdaworks::default();
-}
 impl StarkHash for Pedersen {
     /// Computes the Pedersen hash of two Felts, as defined
     /// in <https://docs.starknet.io/documentation/architecture_and_concepts/Hashing/hash-functions/#pedersen_hash.>
     fn hash(felt_0: &Felt, felt_1: &Felt) -> Felt {
-        Felt(PEDERSEN.hash(&felt_0.0, &felt_1.0))
+        Felt(PedersenStarkCurve::hash(&felt_0.0, &felt_1.0))
     }
 
     /// Computes the Pedersen hash of an array of Felts, as defined
     /// in <https://docs.starknet.io/documentation/architecture_and_concepts/Hashing/hash-functions/#array_hashing.>
     fn hash_array(felts: &[Felt]) -> Felt {
         let data_len = Felt::from(felts.len());
-        let current_hash: FieldElement<Stark252PrimeField> = felts.iter().fold(
-            FieldElement::<Stark252PrimeField>::zero(),
-            |current_hash, felt| PEDERSEN.hash(&current_hash, &felt.0),
-        );
-        Felt(PEDERSEN.hash(&current_hash, &data_len.0))
+        let current_hash: FieldElement<Stark252PrimeField> = felts
+            .iter()
+            .fold(FieldElement::zero(), |current_hash, felt| {
+                PedersenStarkCurve::hash(&current_hash, &felt.0)
+            });
+        Felt(PedersenStarkCurve::hash(&current_hash, &data_len.0))
     }
 }
 


### PR DESCRIPTION
Updates lambdaworks to 0.6.0 to be able to use the optimized Pedersen hash.

This includes a compile-time optimization to reduce the time used to initialize the hash, and arithmetic optimizations to reduce the time of the hash itself.

## Does this introduce a breaking change?

NO ❌ 

## Other information

Merge after the benchmarks PR #48 