### PR TITLE
fix!(core): lazy_static in feature

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -12,20 +12,20 @@ readme = "README.md"
 
 [dependencies]
 bitvec = { version = "1.0.1", default-features = false }
-lambdaworks-math = { version = "0.6.0", default-features = false}
+lambdaworks-math = { version = "0.6.0", default-features = false }
 
 num-traits = { version = "0.2.18", default-features = false }
-num-bigint = { version = "0.4.4",  default-features = false }
-num-integer = { version = "0.1.46",  default-features = false }
-lazy_static = { version = "1.4.0", default-features = false, features = [
-    "spin_no_std",
-] }
+num-bigint = { version = "0.4.4", default-features = false }
+num-integer = { version = "0.1.45", default-features = false }
 
 # Optional
 arbitrary = { version = "1.3.2", optional = true }
-serde = { version = "1.0.197", optional = true, default-features = false, features = ["alloc"] }
+serde = { version = "1.0.197", optional = true, default-features = false, features = [
+  "alloc",
+] }
 lambdaworks-crypto = { version = "0.6.0", default-features = false, optional = true }
 parity-scale-codec = { version = "3.6.9", default-features = false, optional = true }
+lazy_static = { version = "1.4.0", default-features = false, optional = true }
 
 [features]
 default = ["std", "serde", "curve", "num-traits"]
@@ -44,6 +44,7 @@ hash = ["dep:lambdaworks-crypto"]
 arbitrary = ["std", "dep:arbitrary"]
 parity-scale-codec = ["dep:parity-scale-codec"]
 serde = ["alloc", "dep:serde"]
+prime-bigint = ["dep:lazy_static"]
 num-traits = []
 papyrus-serialization = []
 
@@ -54,7 +55,8 @@ serde_test = "1.0.176"
 criterion = "0.5.1"
 rand_chacha = "0.3.1"
 rand = "0.8.5"
+lazy_static = { version = "1.4.0", default-features = false }
 
 [[bench]]
-name= "criterion_pedersen"
-harness=false
+name = "criterion_pedersen"
+harness = false

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -4,17 +4,18 @@ mod felt_arbitrary;
 use core::ops::{Add, Mul, Neg};
 
 use bitvec::array::BitArray;
-use lazy_static::lazy_static;
 use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
-use num_traits::Num;
 use num_traits::{One, Zero};
+#[cfg(any(feature = "prime-bigint", test))]
+use {lazy_static::lazy_static, num_traits::Num};
 
 #[cfg(feature = "num-traits")]
 mod num_traits_impl;
 #[cfg(feature = "papyrus-serialization")]
 mod papyrus_serialization;
 
+#[cfg(any(feature = "prime-bigint", test))]
 lazy_static! {
     pub static ref CAIRO_PRIME_BIGINT: BigInt = BigInt::from_str_radix(
         "800000000000011000000000000000000000000000000000000000000000001",
@@ -486,6 +487,7 @@ impl Felt {
         self.to_biguint().into()
     }
 
+    #[cfg(feature = "prime-bigint")]
     pub fn prime() -> BigUint {
         (*CAIRO_PRIME_BIGINT).to_biguint().unwrap()
     }
@@ -608,7 +610,7 @@ impl From<bool> for Felt {
 
 impl From<&BigInt> for Felt {
     fn from(bigint: &BigInt) -> Felt {
-        let (sign, bytes) = bigint.mod_floor(&CAIRO_PRIME_BIGINT).to_bytes_le();
+        let (sign, bytes) = bigint.to_bytes_le();
         let felt = Felt::from_bytes_le_slice(&bytes);
         if sign == Sign::Minus {
             felt.neg()
@@ -620,7 +622,7 @@ impl From<&BigInt> for Felt {
 
 impl From<BigInt> for Felt {
     fn from(bigint: BigInt) -> Felt {
-        let (sign, bytes) = bigint.mod_floor(&CAIRO_PRIME_BIGINT).to_bytes_le();
+        let (sign, bytes) = bigint.to_bytes_le();
         let felt = Felt::from_bytes_le_slice(&bytes);
         if sign == Sign::Minus {
             felt.neg()
@@ -1451,6 +1453,7 @@ mod test {
         assert_eq!(Felt::MAX.to_bytes_be(), max_bytes);
     }
 
+    #[cfg(feature = "prime-bigint")]
     #[test]
     fn prime() {
         assert_eq!(Felt::prime(), CAIRO_PRIME_BIGINT.to_biguint().unwrap());


### PR DESCRIPTION
lazy_static depends on spin which breaks for `thumbv6m-none-eabi` target (which is in the starknet rs ci) so put that behind a feature flag. THIS IS A BREAKING CHANGE