### PR TITLE
Implement `TryFrom<AffinePoint>` for `ProjectivePoint`

### DIFF
--- a/crates/starknet-types-core/src/curve/projective_point.rs
+++ b/crates/starknet-types-core/src/curve/projective_point.rs
@@ -237,10 +237,10 @@ mod test {
             TryInto::<ProjectivePoint>::try_into(affine_point),
             Err(CurveError::EllipticCurveError(_))
         ));
-  }
-  
-     #[test]
-      fn from_affine_unchecked() {
+    }
+
+    #[test]
+    fn from_affine_unchecked() {
         let a = AffinePoint::new(
             Felt::from_dec_str(
                 "3324833730090626974525872402899302150520188025637965566623476530814354734325",

--- a/crates/starknet-types-core/src/curve/projective_point.rs
+++ b/crates/starknet-types-core/src/curve/projective_point.rs
@@ -65,6 +65,14 @@ impl ProjectivePoint {
     }
 }
 
+impl TryFrom<AffinePoint> for ProjectivePoint {
+    type Error = CurveError;
+
+    fn try_from(affine_point: AffinePoint) -> Result<Self, Self::Error> {
+        Self::from_affine(affine_point.x(), affine_point.y())
+    }
+}
+
 impl ops::Add<&ProjectivePoint> for &ProjectivePoint {
     type Output = ProjectivePoint;
 
@@ -179,6 +187,46 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn try_from_affine() {
+        let projective_point = ProjectivePoint::new(
+            Felt::from_dec_str(
+                "874739451078007766457464989774322083649278607533249481151382481072868806602",
+            )
+            .unwrap(),
+            Felt::from_dec_str(
+                "152666792071518830868575557812948353041420400780739481342941381225525861407",
+            )
+            .unwrap(),
+            Felt::from(1),
+        );
+        let affine_point = projective_point.clone().to_affine().unwrap();
+
+        assert_eq!(
+            TryInto::<ProjectivePoint>::try_into(affine_point).unwrap(),
+            projective_point
+        );
+    }
+
+    #[test]
+    fn try_from_affine_invalid_point() {
+        let affine_point = AffinePoint::new_unchecked(
+            Felt::from_dec_str(
+                "4739451078007766457464989774322083649278607533249481151382481072868806602",
+            )
+            .unwrap(),
+            Felt::from_dec_str(
+                "152666792071518830868575557812948353041420400780739481342941381225525861407",
+            )
+            .unwrap(),
+        );
+
+        assert!(matches!(
+            TryInto::<ProjectivePoint>::try_into(affine_point),
+            Err(CurveError::EllipticCurveError(_))
+        ));
+    }
 
     #[test]
     fn projective_point_identity() {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Feature



## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

This pull request adds the implementation of the `TryFrom<AffinePoint>` trait for the `ProjectivePoint` type. This implementation allows converting an `AffinePoint` to a `ProjectivePoint` if possible, or returning an error if the conversion is not valid according to the elliptic curve arithmetic.

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
