### PR TITLE
feat: Add `Podeidon::hades_permutation`

### DIFF
--- a/crates/starknet-types-core/src/hash/poseidon.rs
+++ b/crates/starknet-types-core/src/hash/poseidon.rs
@@ -30,6 +30,18 @@ impl StarkHash for Poseidon {
     }
 }
 
+impl Poseidon {
+    /// Computes the Hades permutation over a mutable state of 3 Felts, as defined
+    /// in <https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/hash-functions/#poseidon_array_hash>
+    pub fn hades_permutation(state: &mut [Felt; 3]) {
+        let mut state_inner = [state[0].0, state[1].0, state[2].0];
+        PoseidonCairoStark252::hades_permutation(&mut state_inner);
+        for i in 0..3 {
+            state[i] = Felt(state_inner[i]);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -59,5 +71,25 @@ mod tests {
             Felt::from_hex("0x2742e049f7e1613e4a014efeec0d742882a798ae0af8b8dd730358c23848775")
                 .unwrap();
         assert_eq!(Poseidon::hash_array(&[a, b, c]), expected);
+    }
+
+    #[test]
+    fn test_hades_permutation() {
+        let mut state = [
+            Felt::from_hex("0x9").unwrap(),
+            Felt::from_hex("0xb").unwrap(),
+            Felt::from_hex("0x2").unwrap(),
+        ];
+        let expected = [
+            Felt::from_hex("0x510f3a3faf4084e3b1e95fd44c30746271b48723f7ea9c8be6a9b6b5408e7e6")
+                .unwrap(),
+            Felt::from_hex("0x4f511749bd4101266904288021211333fb0a514cb15381af087462fa46e6bd9")
+                .unwrap(),
+            Felt::from_hex("0x186f6dd1a6e79cb1b66d505574c349272cd35c07c223351a0990410798bb9d8")
+                .unwrap(),
+        ];
+        Poseidon::hades_permutation(&mut state);
+
+        assert_eq!(state, expected);
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Feature


## What is the new behavior?

Implements method `hades_permutation` for `Poseidon` struct

## Does this introduce a breaking change?

No

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This change is needed to use this library's poseidon hash in `cairo-vm`'s `PoseidonBuiltinRunner` as it uses the internal permutation function as opossed to using `hash_many`. ([current usage](https://github.com/lambdaclass/cairo-vm/blob/95d2c88fcd4ef799ff64fc392efd633c05fa37e4/vm/src/vm/runners/builtin_runner/poseidon.rs#L96))
<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
