### PR TITLE
Update `docs.rs` & `crates.io` links + Remove mentions of old `stark-felt` crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
  [![GitHub Workflow Status](https://github.com/starknet-io/types-rs/actions/workflows/test.yml/badge.svg)](https://github.com/starknet-io/types-rs/actions/workflows/test.yml)
 [![Project license](https://img.shields.io/github/license/starknet-io/types-rs.svg?style=flat-square)](LICENSE)
 [![Pull Requests welcome](https://img.shields.io/badge/PRs-welcome-ff69b4.svg?style=flat-square)](https://github.com/starknet-io/types-rs/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
-[![Rust docs](https://docs.rs/stark-felt/badge.svg)](https://docs.rs/stark-felt)
+[![Rust docs](https://docs.rs/starknet-types-core/badge.svg)](https://docs.rs/starknet-types-core)
 [![Rust crate](https://img.shields.io/crates/v/sstarknet-types-core.svg)](https://crates.io/crates/starknet-types-core)
 
 This repository is an initiative by a group of maintainers to address the fragmentation in the Starknet Rust ecosystem and improve its interoperability. The key motivation behind this repository is to standardize the representation of the `Felt` (Field Element) type in Rust, which is massively used as the core and atomic type of the Cairo language and its Virtual Machine.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Project license](https://img.shields.io/github/license/starknet-io/types-rs.svg?style=flat-square)](LICENSE)
 [![Pull Requests welcome](https://img.shields.io/badge/PRs-welcome-ff69b4.svg?style=flat-square)](https://github.com/starknet-io/types-rs/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 [![Rust docs](https://docs.rs/starknet-types-core/badge.svg)](https://docs.rs/starknet-types-core)
-[![Rust crate](https://img.shields.io/crates/v/sstarknet-types-core.svg)](https://crates.io/crates/starknet-types-core)
+[![Rust crate](https://img.shields.io/crates/v/starknet-types-core.svg)](https://crates.io/crates/starknet-types-core)
 
 This repository is an initiative by a group of maintainers to address the fragmentation in the Starknet Rust ecosystem and improve its interoperability. The key motivation behind this repository is to standardize the representation of the `Felt` (Field Element) type in Rust, which is massively used as the core and atomic type of the Cairo language and its Virtual Machine.
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ The `Felt` type is currently defined in many different crates and repositories, 
 
 ## Crates
 
-This repository hosts three crates:
+This repository hosts two crates:
 
-- `stark-felt`: This crate provides the universal Felt (Field Element) type for Cairo and STARK proofs.
-
-- `starknet-types-core`: This crate focuses on Starknet types related to computation and execution, requiring performance and optimization for specific arithmetic and cryptographic operations.
+- `starknet-types-core`: This crate provides the universal Felt (Field Element) type for Cairo and STARK proofs. It also focuses on Starknet types related to computation and execution, requiring performance and optimization for specific arithmetic and cryptographic operations.
 
 - `starknet-types-rpc`: This crate deals with Starknet types used in RPC communication, serde, and transport.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Project license](https://img.shields.io/github/license/starknet-io/types-rs.svg?style=flat-square)](LICENSE)
 [![Pull Requests welcome](https://img.shields.io/badge/PRs-welcome-ff69b4.svg?style=flat-square)](https://github.com/starknet-io/types-rs/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 [![Rust docs](https://docs.rs/stark-felt/badge.svg)](https://docs.rs/stark-felt)
-[![Rust crate](https://img.shields.io/crates/v/stark-felt.svg)](https://crates.io/crates/stark-felt)
+[![Rust crate](https://img.shields.io/crates/v/sstarknet-types-core.svg)](https://crates.io/crates/starknet-types-core)
 
 This repository is an initiative by a group of maintainers to address the fragmentation in the Starknet Rust ecosystem and improve its interoperability. The key motivation behind this repository is to standardize the representation of the `Felt` (Field Element) type in Rust, which is massively used as the core and atomic type of the Cairo language and its Virtual Machine.
 

--- a/README.md
+++ b/README.md
@@ -22,21 +22,20 @@ This repository hosts two crates:
 
 ## Usage
 
-You can include any of these crates in your library via crates.io or as a git dependency. For example, to include the `stark-felt` crate, add the following to your `Cargo.toml`:
+You can include any of these crates in your library via crates.io or as a git dependency. For example, to include the `starknet-types-core` crate, add the following to your `Cargo.toml`:
 
 As a crates.io dependency:
 
 ```toml
 [dependencies]
-stark-felt = "0.0.1"
+starknet-types-core = "0.1.0"
 ```
 
 As a git dependency:
 
 ```toml
 [dependencies]
-stark-felt = { git = "https://github.com/starknet-io/types-rs" }
-starknet-types-core = { git = "https://github.com/starknet-io/types-rs.git", version = "0.0.1", default-features = false, features = ["serde"] }
+starknet-types-core = { git = "https://github.com/starknet-io/types-rs.git", version = "0.1.0", default-features = false, features = ["serde"] }
 ```
 
 ## Build from source


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Documentation content changes

## What is the current behavior?

The links to `docs.rs` & `crates.io` in the README point to the old `stark-felt` crate instead of `starknet-core-types`, making it confusing for potential users
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

- The docs.rs & crates.io links now point to the `starknet-core-types` crate
- Mentions of the old `stark-felt` crate were removed from the README

<!-- Please describe the behavior or changes that are being added by this PR. -->


## Does this introduce a breaking change?

No

## Other information

I wasn't able to find `starknet-types-rpc` in crates.io
