### PR TITLE
Update lambdaworks to 0.7.0 

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 bitvec = { version = "1.0.1", default-features = false }
-lambdaworks-math = { version = "0.6.0", default-features = false }
+lambdaworks-math = { version = "0.7.0", default-features = false }
 
 num-traits = { version = "0.2.18", default-features = false }
 num-bigint = { version = "0.4.4", default-features = false }
@@ -23,7 +23,7 @@ arbitrary = { version = "1.3.2", optional = true }
 serde = { version = "1.0.197", optional = true, default-features = false, features = [
   "alloc",
 ] }
-lambdaworks-crypto = { version = "0.6.0", default-features = false, optional = true }
+lambdaworks-crypto = { version = "0.7.0", default-features = false, optional = true }
 parity-scale-codec = { version = "3.6.9", default-features = false, optional = true }
 lazy_static = { version = "1.4.0", default-features = false, optional = true }
 


### PR DESCRIPTION
# Update lambdaworks version to 0.7.0

This version contains a huge update on Poseidon benchmarks ~%60

MAC os benchmarks
```
Benchmarking Poseidon/hash: Collecting 100 samples in estimated 5.0102 s (869k i
Poseidon/hash           time:   [5.6525 µs 5.6551 µs 5.6581 µs]
                        change: [-63.869% -63.775% -63.692%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 21 outliers among 100 measurements (21.00%)
  12 (12.00%) low severe
  3 (3.00%) high mild
  6 (6.00%) high severe

Benchmarking Poseidon/hash_array/10: Collecting 100 samples in estimated 5.1021
Poseidon/hash_array/10  time:   [33.109 µs 33.264 µs 33.460 µs]
                        change: [-64.473% -64.321% -64.164%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking Poseidon/hash_array/100: Collecting 100 samples in estimated 5.8695
Poseidon/hash_array/100 time:   [279.14 µs 279.66 µs 280.33 µs]
                        change: [-64.706% -64.540% -64.371%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking Poseidon/hash_array/1000: Collecting 100 samples in estimated 5.161
Poseidon/hash_array/1000
                        time:   [2.8534 ms 2.8551 ms 2.8577 ms]
                        change: [-63.824% -63.747% -63.686%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Benchmarking Poseidon/hash_array/10000: Collecting 100 samples in estimated 5.65
Poseidon/hash_array/10000
                        time:   [27.680 ms 27.789 ms 27.908 ms]
                        change: [-64.792% -64.660% -64.490%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  12 (12.00%) high severe
```
-----

Linux OS benchmarks

```
Benchmarking Poseidon/hash: Collecting 100 samples in estimated 5.0012 s (737k i
Poseidon/hash           time:   [6.7203 µs 6.7217 µs 6.7233 µs]
                        change: [-64.953% -64.938% -64.922%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe

Benchmarking Poseidon/hash_array/10: Collecting 100 samples in estimated 5.2028
Poseidon/hash_array/10  time:   [40.577 µs 40.586 µs 40.595 µs]
                        change: [-65.003% -64.812% -64.617%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
Benchmarking Poseidon/hash_array/100: Collecting 100 samples in estimated 5.2279
Poseidon/hash_array/100 time:   [339.67 µs 339.72 µs 339.78 µs]
                        change: [-65.012% -64.995% -64.976%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
Benchmarking Poseidon/hash_array/1000: Collecting 100 samples in estimated 5.174
Poseidon/hash_array/1000
                        time:   [3.3929 ms 3.3936 ms 3.3943 ms]
                        change: [-64.447% -64.438% -64.428%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) high mild
  1 (1.00%) high severe
Benchmarking Poseidon/hash_array/10000: Collecting 100 samples in estimated 6.69
Poseidon/hash_array/10000
                        time:   [33.083 ms 33.088 ms 33.093 ms]
                        change: [-65.101% -65.093% -65.085%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
```




## Does this introduce a breaking change?
No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
