### PR TITLE
Implement `FromStr` trait for `Felt`

### DIFF
--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -2,6 +2,7 @@
 mod felt_arbitrary;
 
 use core::ops::{Add, Mul, Neg};
+use core::str::FromStr;
 
 use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
@@ -614,6 +615,18 @@ impl_from!(i16, i128);
 impl_from!(i32, i128);
 impl_from!(i64, i128);
 impl_from!(isize, i128);
+
+impl FromStr for Felt {
+    type Err = FromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with("0x") {
+            Felt::from_hex(s)
+        } else {
+            Felt::from_dec_str(s)
+        }
+    }
+}
 
 impl Add<&Felt> for u64 {
     type Output = Option<u64>;

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -619,6 +619,8 @@ impl_from!(isize, i128);
 impl FromStr for Felt {
     type Err = FromStrError;
 
+    /// Converts a hex (0x-prefixed) or decimal string to a [Felt].
+    /// e.g., '0x123abc' or '1337'.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.starts_with("0x") {
             Felt::from_hex(s)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build-related changes
- Documentation content changes
- Testing
- Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

Can easily call `FromStr::from_str` on either hex or dec string without having to do so manually.

## Does this introduce a breaking change?

No
