### PR TITLE
fix: `ftm::Debug` impl fails to compile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+
+name: "Build feature combinations"
+
+jobs:
+  feature-powerset:
+    name: "Build ${{ matrix.package }} features"
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        package:
+          - "starknet-types-core"
+          - "starknet-types-rpc"
+
+    steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v3"
+
+      - name: "Setup stable toolchain"
+        uses: "actions-rs/toolchain@v1"
+        with:
+          toolchain: "stable"
+          profile: "minimal"
+          override: true
+
+      - name: "Install cargo-hack"
+        run: |
+          cargo install --locked cargo-hack
+
+      - name: "Build all feature combinations"
+        run: |
+          cargo hack build --package ${{ matrix.package }} --feature-powerset

--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -43,7 +43,7 @@ parity-scale-codec = ["dep:parity-scale-codec"]
 serde = ["alloc", "dep:serde"]
 prime-bigint = ["dep:lazy_static"]
 num-traits = []
-papyrus-serialization = []
+papyrus-serialization = ["std"]
 
 [dev-dependencies]
 proptest = "1.4.0"

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -1015,7 +1015,7 @@ mod formatting {
 
     impl fmt::Debug for Felt {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "{}", self.to_fixed_hex_string())
+            write!(f, "{}", self.0)
         }
     }
 
@@ -1107,18 +1107,9 @@ mod test {
 
     #[test]
     fn test_debug_format() {
-        assert_eq!(
-            format!("{:?}", Felt::ONE),
-            String::from("0x") + &"0".repeat(63) + "1"
-        );
-        assert_eq!(
-            format!("{:?}", Felt::from(2)),
-            String::from("0x") + &"0".repeat(63) + "2"
-        );
-        assert_eq!(
-            format!("{:?}", Felt::from(12345)),
-            String::from("0x") + &"0".repeat(60) + "3039"
-        );
+        assert_eq!(format!("{:?}", Felt::ONE), "0x1");
+        assert_eq!(format!("{:?}", Felt::from(2)), "0x2");
+        assert_eq!(format!("{:?}", Felt::from(12345)), "0x3039");
     }
 
     // Helper function to generate a vector of bits for testing purposes


### PR DESCRIPTION
The `ftm::Debug` impl fails to compile unless the `alloc` feature is on. The underlying math lib allows `alloc`-free hex output, except it's not fixed-width like the current impl does.

This technically changes the debug output format, but it should be worth it for getting to avoid requiring `alloc` for just debug printing.

Also adds a GitHub Actions workflow to check that all feature combinations would compile correctly so that this doesn't happen again.