### PR TITLE
Fix FeltVisitor expecting message

### DIFF
--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -960,7 +960,7 @@ mod serde_impl {
         type Value = Felt;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("Failed to deserialize hexadecimal string")
+            formatter.write_str("a felt hexadecimal string")
         }
 
         fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>


### PR DESCRIPTION
# Pull Request type

- Bugfix

## What is the current behavior?

Wrong message used in the `expecting` method of FeltVisitor, not following the documentation:
```
The message should complete the sentence "This Visitor expects to receive ...", for example the message could be "an integer between 0 and 64". The message should not be capitalized and should not end with a period.
```

Issue #81 makes several related reports, some of which have their root in the code imported from lambdaworks. If those parts of the issue are not going to be addressed in this repository, then the issue can be labeled as resolvable by this PR.

## What is the new behavior?

The fixed method now uses the expected message structure.

## Does this introduce a breaking change?

No