### PR TITLE
Bugfix: binary deserialization `Felt`

### DIFF
--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -1116,8 +1116,6 @@ mod test {
     use core::ops::Shl;
     use proptest::prelude::*;
     use regex::Regex;
-    #[cfg(feature = "serde")]
-    use serde_test::{assert_de_tokens, assert_ser_tokens, Configure, Token};
 
     #[test]
     fn test_debug_format() {
@@ -1642,7 +1640,7 @@ mod test {
     #[test]
     #[cfg(feature = "serde")]
     fn serde() {
-        use serde_test::assert_tokens;
+        use serde_test::{assert_tokens, Configure, Token};
 
         assert_tokens(&Felt::ZERO.readable(), &[Token::String("0x0")]);
         assert_tokens(&Felt::TWO.readable(), &[Token::String("0x2")]);

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -1641,187 +1641,35 @@ mod test {
 
     #[test]
     #[cfg(feature = "serde")]
-    fn deserialize() {
-        assert_de_tokens(&Felt::ZERO, &[Token::String("0x0")]);
-        assert_de_tokens(&Felt::TWO, &[Token::String("0x2")]);
-        assert_de_tokens(&Felt::THREE, &[Token::String("0x3")]);
-        assert_de_tokens(
-            &Felt::MAX,
-            &[Token::String(
-                "0x800000000000011000000000000000000000000000000000000000000000000",
-            )],
-        );
-    }
+    fn serde() {
+        use serde_test::assert_tokens;
 
-    #[test]
-    #[cfg(feature = "serde")]
-    fn serialize() {
-        assert_ser_tokens(&Felt::ZERO.readable(), &[Token::String("0x0")]);
-        assert_ser_tokens(&Felt::TWO.readable(), &[Token::String("0x2")]);
-        assert_ser_tokens(&Felt::THREE.readable(), &[Token::String("0x3")]);
-        assert_ser_tokens(
+        assert_tokens(&Felt::ZERO.readable(), &[Token::String("0x0")]);
+        assert_tokens(&Felt::TWO.readable(), &[Token::String("0x2")]);
+        assert_tokens(&Felt::THREE.readable(), &[Token::String("0x3")]);
+        assert_tokens(
             &Felt::MAX.readable(),
             &[Token::String(
                 "0x800000000000011000000000000000000000000000000000000000000000000",
             )],
         );
 
-        assert_ser_tokens(
-            &Felt::ZERO.compact(),
-            &[
-                Token::Seq { len: Some(32) },
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::SeqEnd,
-            ],
-        );
-        assert_ser_tokens(
-            &Felt::TWO.compact(),
-            &[
-                Token::Seq { len: Some(32) },
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(2),
-                Token::SeqEnd,
-            ],
-        );
-        assert_ser_tokens(
-            &Felt::THREE.compact(),
-            &[
-                Token::Seq { len: Some(32) },
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(3),
-                Token::SeqEnd,
-            ],
-        );
-        assert_ser_tokens(
-            &Felt::MAX.compact(),
-            &[
-                Token::Seq { len: Some(32) },
-                Token::U8(8),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(17),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::U8(0),
-                Token::SeqEnd,
-            ],
-        );
+        assert_tokens(&Felt::ZERO.compact(), &[Token::Bytes(&[0; 32])]);
+        static TWO: [u8; 32] = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 2,
+        ];
+        assert_tokens(&Felt::TWO.compact(), &[Token::Bytes(&TWO)]);
+        static THREE: [u8; 32] = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 3,
+        ];
+        assert_tokens(&Felt::THREE.compact(), &[Token::Bytes(&THREE)]);
+        static MAX: [u8; 32] = [
+            8, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ];
+        assert_tokens(&Felt::MAX.compact(), &[Token::Bytes(&MAX)]);
     }
 
     #[test]


### PR DESCRIPTION
`Felt` supports both human readable and binary serialization, but the binary deserializer was missing. 

## Does this introduce a breaking change?

Yes, but likely no-one is affected by it as deserialization was not working. The (de)serialization is done with bytes rather than sequences. 

## Other information

The serialization and deserialization test have been combined.  Serialization and deserialization should not be tested separately as that makes it too easy to miss a case. 
