### PR TITLE
feat: add checked add/mul/sub

### DIFF
--- a/crates/starknet-types-core/src/felt/num_traits_impl.rs
+++ b/crates/starknet-types-core/src/felt/num_traits_impl.rs
@@ -136,7 +136,12 @@ impl CheckedAdd for Felt {
 
 impl CheckedMul for Felt {
     fn checked_mul(&self, v: &Self) -> Option<Self> {
-        let max = self.max(v);
+        let (min, max) = if self < v { (self, v) } else { (v, self) };
+
+        if *min == Felt::ZERO {
+            return Some(*min);
+        }
+
         let res = self * v;
         if res < *max {
             None
@@ -180,6 +185,7 @@ mod tests {
     fn checked_ops() {
         // Add
         assert_eq!(Felt::ONE.checked_add(&Felt::TWO), Some(Felt::THREE));
+        assert_eq!(Felt::ONE.checked_add(&Felt::ZERO), Some(Felt::ONE));
         assert!(Felt::MAX.checked_add(&Felt::ONE).is_none());
         assert!(Felt::ONE.checked_add(&(Felt::MAX)).is_none());
         // Mul
@@ -187,10 +193,12 @@ mod tests {
             Felt::TWO.checked_mul(&Felt::THREE),
             Some(Felt::from_hex_unchecked("0x6"))
         );
+        assert_eq!(Felt::TWO.checked_mul(&Felt::ZERO), Some(Felt::ZERO));
         assert!(Felt::MAX.checked_mul(&Felt::TWO).is_none());
         assert!(Felt::TWO.checked_mul(&Felt::MAX).is_none());
         // Sub
         assert_eq!(Felt::THREE.checked_sub(&Felt::TWO), Some(Felt::ONE));
+        assert_eq!(Felt::THREE.checked_sub(&Felt::ZERO), Some(Felt::THREE));
         assert!(Felt::ONE.checked_sub(&Felt::TWO).is_none());
     }
 }

--- a/crates/starknet-types-core/src/felt/num_traits_impl.rs
+++ b/crates/starknet-types-core/src/felt/num_traits_impl.rs
@@ -136,8 +136,9 @@ impl CheckedAdd for Felt {
 
 impl CheckedMul for Felt {
     fn checked_mul(&self, v: &Self) -> Option<Self> {
+        let max = self.max(v);
         let res = self * v;
-        if res < *self {
+        if res < *max {
             None
         } else {
             Some(res)
@@ -177,13 +178,18 @@ mod tests {
 
     #[test]
     fn checked_ops() {
+        // Add
         assert_eq!(Felt::ONE.checked_add(&Felt::TWO), Some(Felt::THREE));
         assert!(Felt::MAX.checked_add(&Felt::ONE).is_none());
+        assert!(Felt::ONE.checked_add(&(Felt::MAX)).is_none());
+        // Mul
         assert_eq!(
             Felt::TWO.checked_mul(&Felt::THREE),
             Some(Felt::from_hex_unchecked("0x6"))
         );
         assert!(Felt::MAX.checked_mul(&Felt::TWO).is_none());
+        assert!(Felt::TWO.checked_mul(&Felt::MAX).is_none());
+        // Sub
         assert_eq!(Felt::THREE.checked_sub(&Felt::TWO), Some(Felt::ONE));
         assert!(Felt::ONE.checked_sub(&Felt::TWO).is_none());
     }


### PR DESCRIPTION
## What is the current behavior?

Checked operation traits are not available for Felt.
## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Following traits are implemented 
- CheckedAdd
- CheckedMul
- CheckedSub

## Does this introduce a breaking change?

No

## Other information

It would make sense to impl CheckedDiv too. But the trait requires that `Div` be implemented. Something we chose to not do so far. It may be worth reconsidering this.
