### PR TITLE
feat: improve poseidon API

### DIFF
--- a/crates/starknet-types-core/src/hash/pedersen.rs
+++ b/crates/starknet-types-core/src/hash/pedersen.rs
@@ -26,6 +26,10 @@ impl StarkHash for Pedersen {
             });
         Felt(PedersenStarkCurve::hash(&current_hash, &data_len.0))
     }
+    
+    fn hash_single(felt: &Felt) -> Felt {
+        todo!()
+    }
 }
 
 #[cfg(test)]

--- a/crates/starknet-types-core/src/hash/poseidon.rs
+++ b/crates/starknet-types-core/src/hash/poseidon.rs
@@ -28,6 +28,10 @@ impl StarkHash for Poseidon {
             )
         }))
     }
+
+    fn hash_single(felt: &Felt) -> Felt {
+        Felt(PoseidonCairoStark252::hash_single(&felt.0))
+    }
 }
 
 impl Poseidon {
@@ -45,6 +49,17 @@ impl Poseidon {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_poseidon_single() {
+        let x = Felt::from_hex("0x9").unwrap();
+
+        assert_eq!(
+            Poseidon::hash_single(&x),
+            Felt::from_hex("0x3bb3b91c714cb47003947f36dadc98326176963c434cd0a10320b8146c948b3")
+                .unwrap()
+        );
+    }
 
     #[test]
     fn test_poseidon_hash() {

--- a/crates/starknet-types-core/src/hash/traits.rs
+++ b/crates/starknet-types-core/src/hash/traits.rs
@@ -7,4 +7,6 @@ pub trait StarkHash {
     /// Computes the hash of an array of Felts,
     /// as defined in <https://docs.starknet.io/documentation/architecture_and_concepts/Hashing/hash-functions/#array_hashing.>
     fn hash_array(felts: &[Felt]) -> Felt;
+
+    fn hash_single(felt: &Felt) -> Felt;
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

StarkHash trait does have `hash_single` funciton

Resolves: https://github.com/starknet-io/types-rs/issues/107

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- StarkHash now implements `hash_single` function

## Does this introduce a breaking change?

No

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

This results in Pedersen needing to implement `hash_single` as well. Currently, it is set as todo!
