### PR TITLE
 Implement `new_from_x` for AffinePoint to create a new point from compressed representation.

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-types-core"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/starknet-io/types-rs"


### PR DESCRIPTION
# Pull Request type
- Feature

## What is the current behavior?

AffinePoint can't be created just from the X coordinate

## What is the new behavior?
AffinePoint can be created from the X coordinate and the parity bit
 - if the parity bit is 0, choose the y-coordinate with even parity.
 - If the parity bit is 1, choose the y-coordinate with odd parity.

## Does this introduce a breaking change?

No
