### PR TITLE
Add `Arbitrary` size hint

### DIFF
--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -463,6 +463,11 @@ impl Arbitrary<'_> for Felt {
         let felt = FieldElement::new(uint);
         Ok(Felt(felt))
     }
+
+    #[inline]
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        <[u64; 4]>::size_hint(depth)
+    }
 }
 
 /// Allows transparent binary serialization of Felts with `parity_scale_codec`.


### PR DESCRIPTION
## What is the current behavior?

`<Felt as Arbitrary>::size_hint` returns `0`

## What is the new behavior?

Correctly returns the amount of bytes to construct a `Felt`.


