### PR TITLE
Remove `SizeOf` implementation for `Felt`

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -15,7 +15,6 @@ lambdaworks-math = { version = "0.10.0", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
 num-integer = { version = "0.1", default-features = false }
-size-of = { version = "0.1.5", default-features = false }
 
 # Optional
 arbitrary = { version = "1.3", optional = true }

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -31,7 +31,6 @@ use core::str::FromStr;
 use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
 use num_traits::{One, Zero};
-use size_of::SizeOf;
 
 #[cfg(feature = "alloc")]
 pub extern crate alloc;
@@ -48,10 +47,6 @@ use lambdaworks_math::{
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Felt(pub(crate) FieldElement<Stark252PrimeField>);
-
-impl SizeOf for Felt {
-    fn size_of_children(&self, _context: &mut size_of::Context) {}
-}
 
 #[derive(Debug)]
 pub struct FromStrError(CreationError);
@@ -796,7 +791,6 @@ mod test {
     use num_traits::Num;
     use proptest::prelude::*;
     use regex::Regex;
-    use size_of::TotalSize;
 
     #[test]
     fn test_debug_format() {
@@ -1357,16 +1351,5 @@ mod test {
         let one: Felt = true.into();
         assert_eq!(one, Felt::ONE);
         assert_eq!(zero, Felt::ZERO);
-    }
-
-    #[test]
-    fn felt_size_of() {
-        assert_eq!(Felt::ZERO.size_of(), TotalSize::total(32));
-        assert_eq!(Felt::ONE.size_of(), TotalSize::total(32));
-        assert_eq!(
-            Felt(FieldElement::from(1600000000)).size_of(),
-            TotalSize::total(32)
-        );
-        assert_eq!(Felt::MAX.size_of(), TotalSize::total(32));
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Reverts #123

`size-of` crate is unmaintained and doesn't compile on architectures other than `x86` when Rust version is `>1.89`.
See the [issue in `size-of`](https://github.com/Kixiron/size-of/issues/6) and [explanation of the error in Rust compiler](https://github.com/rust-lang/rust/issues/87678).

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build-related changes
- Documentation content changes
- Testing
- Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

Theoretically, this is a breaking change. However, no crate actually uses the implementation of `SizeOf`, so in practice it isn't. 

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
