### PR TITLE
feat: add a u256 type

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -21,7 +21,7 @@ arbitrary = { version = "1.3", optional = true }
 blake2 = { version = "0.10.6", default-features = false, optional = true }
 digest = { version = "0.10.7", optional = true }
 serde = { version = "1", optional = true, default-features = false, features = [
-  "alloc",
+  "alloc", "derive"
 ] }
 lambdaworks-crypto = { version = "0.10.0", default-features = false, optional = true }
 parity-scale-codec = { version = "3.6", default-features = false, optional = true }

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -31,6 +31,7 @@ use core::str::FromStr;
 use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
 use num_traits::{One, Zero};
+pub use primitive_conversions::PrimitiveFromFeltError;
 
 #[cfg(feature = "alloc")]
 pub extern crate alloc;

--- a/crates/starknet-types-core/src/lib.rs
+++ b/crates/starknet-types-core/src/lib.rs
@@ -9,3 +9,4 @@ pub mod felt;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub mod short_string;
+pub mod u256;

--- a/crates/starknet-types-core/src/u256/mod.rs
+++ b/crates/starknet-types-core/src/u256/mod.rs
@@ -9,6 +9,9 @@
 //! We recommand you create From/Into implementation to bridge the gap between your favourite u256 type,
 //! and the one provided by this crate.
 
+#[cfg(feature = "num-traits")]
+mod num_traits_impl;
+mod primitive_conversions;
 #[cfg(test)]
 mod tests;
 
@@ -194,8 +197,9 @@ impl U256 {
             let mut low = 0u128;
             let mut high = 0u128;
 
-            // b is ascii value of the char - ascii value of the char '0',
+            // b is ascii value of the char less the ascii value of the char '0'
             // which happen to be equal to the number represented by the char.
+            // b = ascii(char) - ascii('0')
             for b in string_without_zero_padding
                 .bytes()
                 .map(|b| b.wrapping_sub(b'0'))
@@ -298,43 +302,3 @@ impl FromStr for U256 {
         }
     }
 }
-
-macro_rules! impl_from_uint {
-    ($from:ty) => {
-        impl From<$from> for U256 {
-            fn from(value: $from) -> U256 {
-                U256 {
-                    high: 0,
-                    low: value.into(),
-                }
-            }
-        }
-    };
-}
-
-impl_from_uint!(u8);
-impl_from_uint!(u16);
-impl_from_uint!(u32);
-impl_from_uint!(u64);
-impl_from_uint!(u128);
-
-macro_rules! impl_try_from_int {
-    ($from:ty) => {
-        impl TryFrom<$from> for U256 {
-            type Error = core::num::TryFromIntError;
-
-            fn try_from(value: $from) -> Result<Self, Self::Error> {
-                Ok(U256 {
-                    high: 0,
-                    low: value.try_into()?,
-                })
-            }
-        }
-    };
-}
-
-impl_try_from_int!(i8);
-impl_try_from_int!(i16);
-impl_try_from_int!(i32);
-impl_try_from_int!(i64);
-impl_try_from_int!(i128);

--- a/crates/starknet-types-core/src/u256/mod.rs
+++ b/crates/starknet-types-core/src/u256/mod.rs
@@ -1,0 +1,196 @@
+#[cfg(test)]
+mod tests;
+
+use core::{fmt::Debug, str::FromStr};
+
+use crate::felt::{Felt, PrimitiveFromFeltError};
+
+#[derive(Debug)]
+pub enum FromStrError {
+    ValueTooBig,
+    Invalid,
+    Parse(<u128 as FromStr>::Err),
+}
+
+impl core::fmt::Display for FromStrError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            FromStrError::ValueTooBig => core::fmt::Display::fmt("value too big for u256", f),
+            FromStrError::Parse(e) => {
+                // Avoid using format as it requires `alloc`
+                core::fmt::Display::fmt("invalid string: ", f)?;
+                core::fmt::Display::fmt(e, f)
+            }
+            FromStrError::Invalid => core::fmt::Display::fmt("invalid characters", f),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FromStrError {}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct U256 {
+    high: u128,
+    low: u128,
+}
+
+impl U256 {
+    pub fn high(&self) -> u128 {
+        self.high
+    }
+
+    pub fn low(&self) -> u128 {
+        self.low
+    }
+
+    pub fn from_parts(high: u128, low: u128) -> Self {
+        Self { low, high }
+    }
+
+    pub fn try_from_felt_parts(high: Felt, low: Felt) -> Result<Self, PrimitiveFromFeltError> {
+        Ok(Self {
+            high: high.try_into()?,
+            low: low.try_into()?,
+        })
+    }
+
+    pub fn try_from_dec_str_parts(high: &str, low: &str) -> Result<Self, <u128 as FromStr>::Err> {
+        Ok(Self {
+            high: high.parse()?,
+            low: low.parse()?,
+        })
+    }
+
+    pub fn try_from_hex_str_parts(high: &str, low: &str) -> Result<Self, <u128 as FromStr>::Err> {
+        Ok(Self {
+            high: u128::from_str_radix(high, 16)?,
+            low: u128::from_str_radix(low, 16)?,
+        })
+    }
+
+    pub fn from_hex_str(hex_str: &str) -> Result<Self, FromStrError> {
+        let string_without_prefix = if hex_str.starts_with("0x") || hex_str.starts_with("0X") {
+            &hex_str[2..]
+        } else {
+            hex_str
+        };
+
+        let string_without_zero_padding = string_without_prefix.trim_start_matches('0');
+
+        let (high, low) = if string_without_zero_padding.is_empty() {
+            if string_without_zero_padding.len() == string_without_prefix.len() {
+                return Err(FromStrError::Invalid);
+            } else {
+                (0, 0)
+            }
+        } else if string_without_zero_padding.len() > 64 {
+            return Err(FromStrError::ValueTooBig);
+        } else if string_without_zero_padding.len() > 32 {
+            let delimiter_index = string_without_zero_padding.len() - 32;
+            (
+                u128::from_str_radix(&string_without_zero_padding[0..delimiter_index], 16)
+                    .map_err(FromStrError::Parse)?,
+                u128::from_str_radix(&string_without_zero_padding[delimiter_index..], 16)
+                    .map_err(FromStrError::Parse)?,
+            )
+        } else {
+            (
+                0,
+                u128::from_str_radix(string_without_zero_padding, 16)
+                    .map_err(FromStrError::Parse)?,
+            )
+        };
+
+        Ok(U256 { high, low })
+    }
+
+    pub fn from_dec_str(dec_str: &str) -> Result<Self, FromStrError> {
+        let string_without_zero_padding = dec_str.trim_start_matches('0');
+
+        let (high, low) = if string_without_zero_padding.is_empty() {
+            if string_without_zero_padding.len() == dec_str.len() {
+                return Err(FromStrError::Invalid);
+            } else {
+                (0, 0)
+            }
+        } else if string_without_zero_padding.len() > 78 {
+            return Err(FromStrError::ValueTooBig);
+        } else if string_without_zero_padding.len() < 39 {
+            (
+                0,
+                string_without_zero_padding
+                    .parse()
+                    .map_err(FromStrError::Parse)?,
+            )
+        } else {
+            let mut low = 0u128;
+            let mut high = 0u128;
+            for b in string_without_zero_padding
+                .bytes()
+                .map(|b| b.wrapping_sub(b'0'))
+            {
+                if b > 9 {
+                    return Err(FromStrError::Invalid);
+                }
+                let (new_high, did_overflow) = high.overflowing_mul(10);
+                if did_overflow {
+                    return Err(FromStrError::ValueTooBig);
+                }
+                // Long multiplication to get both result and carry
+                let (new_low, carry) = {
+                    let low_low = low as u64;
+                    let low_high = (low >> 64) as u64;
+
+                    let low_low = (low_low as u128) * 10;
+                    let low_high = (low_high as u128) * 10;
+                    let (result, did_overflow) = low_low.overflowing_add(low_high << 64);
+                    // I couldn't come up with a value where `did_overflow` is true,
+                    // but better safe than sorry
+                    let carry = (low_high >> 64) + if did_overflow { 1 } else { 0 };
+                    (result, carry)
+                };
+
+                let new_high = if carry != 0 {
+                    let (new_high, did_overflow) = new_high.overflowing_add(carry);
+                    if did_overflow {
+                        return Err(FromStrError::ValueTooBig);
+                    }
+                    new_high
+                } else {
+                    new_high
+                };
+
+                let (new_low, did_overflow) = new_low.overflowing_add(b.into());
+                if did_overflow {
+                    let (new_high, carry) = new_high.overflowing_add(1);
+                    if carry {
+                        return Err(FromStrError::ValueTooBig);
+                    }
+                    high = new_high;
+                } else {
+                    high = new_high;
+                }
+
+                low = new_low
+            }
+
+            (high, low)
+        };
+
+        Ok(U256 { high, low })
+    }
+}
+
+impl FromStr for U256 {
+    type Err = FromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with("0x") || s.starts_with("0X") {
+            Self::from_hex_str(s)
+        } else {
+            Self::from_dec_str(s)
+        }
+    }
+}

--- a/crates/starknet-types-core/src/u256/mod.rs
+++ b/crates/starknet-types-core/src/u256/mod.rs
@@ -135,17 +135,16 @@ impl U256 {
             hex_str
         };
 
+        if string_without_prefix.is_empty() {
+            return Err(FromStrError::Invalid);
+        }
+
         // Remove leading zero
         let string_without_zero_padding = string_without_prefix.trim_start_matches('0');
 
         let (high, low) = if string_without_zero_padding.is_empty() {
-            if string_without_zero_padding.len() == string_without_prefix.len() {
-                // The string is truly empty
-                return Err(FromStrError::Invalid);
-            } else {
-                // The string was uniquely made out of of `0`
-                (0, 0)
-            }
+            // The string was uniquely made out of of `0`
+            (0, 0)
         } else if string_without_zero_padding.len() > 64 {
             return Err(FromStrError::StringTooLong);
         } else if string_without_zero_padding.len() > 32 {
@@ -179,17 +178,16 @@ impl U256 {
     /// silent wraparound and ensures accurate representation of large decimal numbers.
     /// Values with more than 78 decimal digits are rejected as they exceed U256 capacity.
     pub fn from_dec_str(dec_str: &str) -> Result<Self, FromStrError> {
+        if dec_str.is_empty() {
+            return Err(FromStrError::Invalid);
+        }
+
         // Ignore leading zeros
         let string_without_zero_padding = dec_str.trim_start_matches('0');
 
         let (high, low) = if string_without_zero_padding.is_empty() {
-            if string_without_zero_padding.len() == dec_str.len() {
-                // The string is truly empty
-                return Err(FromStrError::Invalid);
-            } else {
-                // The string was uniquely made out of of `0`
-                (0, 0)
-            }
+            // The string was uniquely made out of of `0`
+            (0, 0)
         } else if string_without_zero_padding.len() > 78 {
             return Err(FromStrError::StringTooLong);
         } else {

--- a/crates/starknet-types-core/src/u256/mod.rs
+++ b/crates/starknet-types-core/src/u256/mod.rs
@@ -300,3 +300,43 @@ impl FromStr for U256 {
         }
     }
 }
+
+macro_rules! impl_from_uint {
+    ($from:ty) => {
+        impl From<$from> for U256 {
+            fn from(value: $from) -> U256 {
+                U256 {
+                    high: 0,
+                    low: value.into(),
+                }
+            }
+        }
+    };
+}
+
+impl_from_uint!(u8);
+impl_from_uint!(u16);
+impl_from_uint!(u32);
+impl_from_uint!(u64);
+impl_from_uint!(u128);
+
+macro_rules! impl_try_from_int {
+    ($from:ty) => {
+        impl TryFrom<$from> for U256 {
+            type Error = core::num::TryFromIntError;
+
+            fn try_from(value: $from) -> Result<Self, Self::Error> {
+                Ok(U256 {
+                    high: 0,
+                    low: value.try_into()?,
+                })
+            }
+        }
+    };
+}
+
+impl_try_from_int!(i8);
+impl_try_from_int!(i16);
+impl_try_from_int!(i32);
+impl_try_from_int!(i64);
+impl_try_from_int!(i128);

--- a/crates/starknet-types-core/src/u256/mod.rs
+++ b/crates/starknet-types-core/src/u256/mod.rs
@@ -1,3 +1,14 @@
+//! A Cairo-like u256 type.
+//!
+//! This `U256` type purpose is not to be used to perfomr arithmetic operations,
+//! but rather to offer a handy interface to convert from and to Cairo's u256 values.
+//! Indeed, the Cairo language represent u256 values as a two felts struct,
+//! representing the `low` and `high` 128 bits of the value.
+//! We mirror this representation, allowing for efficient serialization/deserializatin.
+//!
+//! We recommand you create From/Into implementation to bridge the gap between your favourite u256 type,
+//! and the one provided by this crate.
+
 #[cfg(test)]
 mod tests;
 
@@ -5,10 +16,16 @@ use core::{fmt::Debug, str::FromStr};
 
 use crate::felt::{Felt, PrimitiveFromFeltError};
 
+/// Error types that can occur when parsing a string into a U256.
 #[derive(Debug)]
 pub enum FromStrError {
+    /// The string contain too many characters to be the representation of a valid u256 value.
+    StringTooLong,
+    /// The parsed value exceeds the maximum representable value for U256.
     ValueTooBig,
+    /// The string contains invalid characters for the expected format.
     Invalid,
+    /// Underlying u128 parsing failed.
     Parse(<u128 as FromStr>::Err),
 }
 
@@ -16,12 +33,15 @@ impl core::fmt::Display for FromStrError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             FromStrError::ValueTooBig => core::fmt::Display::fmt("value too big for u256", f),
+            FromStrError::Invalid => core::fmt::Display::fmt("invalid characters", f),
             FromStrError::Parse(e) => {
                 // Avoid using format as it requires `alloc`
                 core::fmt::Display::fmt("invalid string: ", f)?;
                 core::fmt::Display::fmt(e, f)
             }
-            FromStrError::Invalid => core::fmt::Display::fmt("invalid characters", f),
+            FromStrError::StringTooLong => {
+                core::fmt::Display::fmt("too many characters to be a valid u256 represenation", f)
+            }
         }
     }
 }
@@ -29,6 +49,11 @@ impl core::fmt::Display for FromStrError {
 #[cfg(feature = "std")]
 impl std::error::Error for FromStrError {}
 
+/// A 256-bit unsigned integer represented as two 128-bit components.
+///
+/// The internal representation uses big-endian ordering where `high` contains
+/// the most significant 128 bits and `low` contains the least significant 128 bits.
+/// This reflects the way u256 are represented in the Cairo language.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct U256 {
@@ -37,18 +62,28 @@ pub struct U256 {
 }
 
 impl U256 {
+    /// Returns the high 128 bits of the U256 value.
     pub fn high(&self) -> u128 {
         self.high
     }
 
+    /// Returns the low 128 bits of the U256 value.
     pub fn low(&self) -> u128 {
         self.low
     }
 
+    /// Constructs a U256 from explicit high and low 128-bit components.
+    ///
+    /// This is the most direct way to create a U256 when you already have
+    /// the component values separated.
     pub fn from_parts(high: u128, low: u128) -> Self {
         Self { low, high }
     }
 
+    /// Attempts to construct a U256 from two Felt values representing high and low parts.
+    ///
+    /// This conversion can fail if either Felt value cannot be represented as a u128,
+    /// which would indicate the Felt contains a value outside the valid range.
     pub fn try_from_felt_parts(high: Felt, low: Felt) -> Result<Self, PrimitiveFromFeltError> {
         Ok(Self {
             high: high.try_into()?,
@@ -56,6 +91,9 @@ impl U256 {
         })
     }
 
+    /// Attempts to construct a U256 from decimal string representations of high and low parts.
+    ///
+    /// Both strings must be valid decimal representations that fit within u128 range.
     pub fn try_from_dec_str_parts(high: &str, low: &str) -> Result<Self, <u128 as FromStr>::Err> {
         Ok(Self {
             high: high.parse()?,
@@ -63,31 +101,56 @@ impl U256 {
         })
     }
 
+    /// Attempts to construct a U256 from hexadecimal string representations of high and low parts.
+    ///
+    /// Both strings must be valid hexadecimal (prefixed or not) representations that fit within u128 range.
     pub fn try_from_hex_str_parts(high: &str, low: &str) -> Result<Self, <u128 as FromStr>::Err> {
+        let high = if high.starts_with("0x") || high.starts_with("0X") {
+            &high[2..]
+        } else {
+            high
+        };
+        let low = if low.starts_with("0x") || low.starts_with("0X") {
+            &low[2..]
+        } else {
+            low
+        };
+
         Ok(Self {
             high: u128::from_str_radix(high, 16)?,
             low: u128::from_str_radix(low, 16)?,
         })
     }
 
+    /// Parses a hexadecimal string into a U256 value.
+    ///
+    /// Accepts strings with or without "0x"/"0X" prefixes and handles leading zero removal.
+    /// The implementation automatically determines the split between high and low components
+    /// based on string length, with values over 32 hex digits requiring high component usage.
     pub fn from_hex_str(hex_str: &str) -> Result<Self, FromStrError> {
+        // Remove prefix
         let string_without_prefix = if hex_str.starts_with("0x") || hex_str.starts_with("0X") {
             &hex_str[2..]
         } else {
             hex_str
         };
 
+        // Remove leading zero
         let string_without_zero_padding = string_without_prefix.trim_start_matches('0');
 
         let (high, low) = if string_without_zero_padding.is_empty() {
             if string_without_zero_padding.len() == string_without_prefix.len() {
+                // The string is truly empty
                 return Err(FromStrError::Invalid);
             } else {
+                // The string was uniquely made out of of `0`
                 (0, 0)
             }
         } else if string_without_zero_padding.len() > 64 {
-            return Err(FromStrError::ValueTooBig);
+            return Err(FromStrError::StringTooLong);
         } else if string_without_zero_padding.len() > 32 {
+            // The 32 last characters are the `low` u128 bytes,
+            // all the other ones are the `high` u128 bytes.
             let delimiter_index = string_without_zero_padding.len() - 32;
             (
                 u128::from_str_radix(&string_without_zero_padding[0..delimiter_index], 16)
@@ -96,6 +159,7 @@ impl U256 {
                     .map_err(FromStrError::Parse)?,
             )
         } else {
+            // There is no `high` bytes.
             (
                 0,
                 u128::from_str_radix(string_without_zero_padding, 16)
@@ -106,54 +170,88 @@ impl U256 {
         Ok(U256 { high, low })
     }
 
+    /// Parses a decimal string into a `u256`.
+    ///
+    /// Custom arithmetic is executed in order to efficiently parse the input as two `u128` values.
+    ///
+    /// This implementation performs digit-by-digit multiplication to handle values
+    /// that exceed u128 range. The algorithm uses overflow detection to prevent
+    /// silent wraparound and ensures accurate representation of large decimal numbers.
+    /// Values with more than 78 decimal digits are rejected as they exceed U256 capacity.
     pub fn from_dec_str(dec_str: &str) -> Result<Self, FromStrError> {
+        // Ignore leading zeros
         let string_without_zero_padding = dec_str.trim_start_matches('0');
 
         let (high, low) = if string_without_zero_padding.is_empty() {
             if string_without_zero_padding.len() == dec_str.len() {
+                // The string is truly empty
                 return Err(FromStrError::Invalid);
             } else {
+                // The string was uniquely made out of of `0`
                 (0, 0)
             }
         } else if string_without_zero_padding.len() > 78 {
-            return Err(FromStrError::ValueTooBig);
-        } else if string_without_zero_padding.len() < 39 {
-            (
-                0,
-                string_without_zero_padding
-                    .parse()
-                    .map_err(FromStrError::Parse)?,
-            )
+            return Err(FromStrError::StringTooLong);
         } else {
             let mut low = 0u128;
             let mut high = 0u128;
+
+            // b is ascii value of the char - ascii value of the char '0',
+            // which happen to be equal to the number represented by the char.
             for b in string_without_zero_padding
                 .bytes()
                 .map(|b| b.wrapping_sub(b'0'))
             {
+                // Using `wrapping_sub` all non 0-9 characters will yield a value greater than 9.
                 if b > 9 {
                     return Err(FromStrError::Invalid);
                 }
+
+                // We use a [long multiplication](https://en.wikipedia.org/wiki/Multiplication_algorithm#Long_multiplication)
+                // algorithm to perform the computation.
+                // The idea is that if
+                // `v = (high << 128) + low`
+                // then
+                // `v * 10 = ((high * 10) << 128) + low * 10`
+
+                // Compute `high * 10`, return error on overflow.
                 let (new_high, did_overflow) = high.overflowing_mul(10);
                 if did_overflow {
                     return Err(FromStrError::ValueTooBig);
                 }
-                // Long multiplication to get both result and carry
+                // Now we want to compute `low * 10`, but in case it overflows, we want to carry rather than error.
+                // To do so, we perform another long multiplication to get both the result and carry values,
+                // this time breaking the u128 (low) value into two u64 (low_low and low_high),
+                // perform multiplication on each part individually, extracting an eventual carry, and finally
+                // combining them back.
+                //
+                // Any overflow on the high part will result in an error.
+                // Any overflow on the low part should be handled by carrying the extra amount to the high part.
                 let (new_low, carry) = {
                     let low_low = low as u64;
                     let low_high = (low >> 64) as u64;
 
+                    // Both of those values cannot overflow, as they are u64 stored into a u128.
+                    // Intead they will just start using the highest half part of their bytes.
                     let low_low = (low_low as u128) * 10;
                     let low_high = (low_high as u128) * 10;
-                    let (result, did_overflow) = low_low.overflowing_add(low_high << 64);
+
+                    // The carry of the multiplication per 10 is in the highest 64 bytes of the `low_high` part.
+                    let carry_mul_10 = low_high >> 64;
+                    // We shift back the bytes, erasing any carry we may have.
+                    let low_high_without_carry = low_high << 64;
+
+                    // By adding back the two low parts together we get its new value.
+                    let (new_low, did_overflow) = low_low.overflowing_add(low_high_without_carry);
                     // I couldn't come up with a value where `did_overflow` is true,
                     // but better safe than sorry
-                    let carry = (low_high >> 64) + if did_overflow { 1 } else { 0 };
-                    (result, carry)
+                    (new_low, carry_mul_10 + if did_overflow { 1 } else { 0 })
                 };
 
+                // Add carry to high if it exists.
                 let new_high = if carry != 0 {
                     let (new_high, did_overflow) = new_high.overflowing_add(carry);
+                    // Error if it overflows.
                     if did_overflow {
                         return Err(FromStrError::ValueTooBig);
                     }
@@ -162,10 +260,14 @@ impl U256 {
                     new_high
                 };
 
+                // Add the new digit to low.
                 let (new_low, did_overflow) = new_low.overflowing_add(b.into());
+
+                // Add one to high if the previous operation overflowed.
                 if did_overflow {
-                    let (new_high, carry) = new_high.overflowing_add(1);
-                    if carry {
+                    let (new_high, did_overflow) = new_high.overflowing_add(1);
+                    // Error if it overflows.
+                    if did_overflow {
                         return Err(FromStrError::ValueTooBig);
                     }
                     high = new_high;
@@ -186,6 +288,10 @@ impl U256 {
 impl FromStr for U256 {
     type Err = FromStrError;
 
+    /// Parses a string into a U256 by detecting the format automatically.
+    ///
+    /// Strings beginning with "0x" or "0X" are treated as hexadecimal,
+    /// while all other strings are interpreted as decimal.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.starts_with("0x") || s.starts_with("0X") {
             Self::from_hex_str(s)

--- a/crates/starknet-types-core/src/u256/num_traits_impl.rs
+++ b/crates/starknet-types-core/src/u256/num_traits_impl.rs
@@ -1,0 +1,82 @@
+use num_bigint::{BigInt, BigUint, ToBigInt, ToBigUint};
+use num_traits::{FromPrimitive, ToPrimitive};
+
+use super::U256;
+
+impl ToBigUint for U256 {
+    fn to_biguint(&self) -> Option<BigUint> {
+        let mut buffer = [0u8; 32];
+
+        buffer[..16].copy_from_slice(&self.high.to_be_bytes());
+        buffer[16..].copy_from_slice(&self.low.to_be_bytes());
+
+        Some(BigUint::from_bytes_be(&buffer))
+    }
+}
+
+impl ToBigInt for U256 {
+    fn to_bigint(&self) -> Option<BigInt> {
+        self.to_biguint().map(|v| v.into())
+    }
+}
+
+impl FromPrimitive for U256 {
+    fn from_i64(value: i64) -> Option<Self> {
+        value.try_into().ok()
+    }
+
+    fn from_u64(value: u64) -> Option<Self> {
+        Some(value.into())
+    }
+    fn from_i128(value: i128) -> Option<Self> {
+        value.try_into().ok()
+    }
+
+    fn from_u128(value: u128) -> Option<Self> {
+        Some(value.into())
+    }
+}
+
+impl ToPrimitive for U256 {
+    fn to_i64(&self) -> Option<i64> {
+        (*self).try_into().ok()
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        (*self).try_into().ok()
+    }
+
+    fn to_i128(&self) -> Option<i128> {
+        (*self).try_into().ok()
+    }
+
+    fn to_u128(&self) -> Option<u128> {
+        (*self).try_into().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn to_bigint() {
+        let big_value =
+            "115000000000000000000000000000000000000000000000000000000000000000000000000000";
+        let bigint = BigInt::from_str(big_value).unwrap();
+        let u256 = U256::from_dec_str(big_value).unwrap();
+        let converted = u256.to_bigint().unwrap();
+        assert_eq!(bigint, converted);
+    }
+    #[test]
+    fn to_biguint() {
+        let big_value =
+            "115000000000000000000000000000000000000000000000000000000000000000000000000000";
+        let biguint = BigInt::from_str(big_value).unwrap();
+        let u256 = U256::from_dec_str(big_value).unwrap();
+        let converted = u256.to_bigint().unwrap();
+        assert_eq!(biguint, converted);
+    }
+}

--- a/crates/starknet-types-core/src/u256/primitive_conversions.rs
+++ b/crates/starknet-types-core/src/u256/primitive_conversions.rs
@@ -1,0 +1,82 @@
+use core::fmt::Display;
+
+use super::U256;
+
+macro_rules! impl_from_uint {
+    ($from:ty) => {
+        impl From<$from> for U256 {
+            fn from(value: $from) -> U256 {
+                U256 {
+                    high: 0,
+                    low: value.into(),
+                }
+            }
+        }
+    };
+}
+
+impl_from_uint!(u8);
+impl_from_uint!(u16);
+impl_from_uint!(u32);
+impl_from_uint!(u64);
+impl_from_uint!(u128);
+
+macro_rules! impl_try_from_int {
+    ($from:ty) => {
+        impl TryFrom<$from> for U256 {
+            type Error = core::num::TryFromIntError;
+
+            fn try_from(value: $from) -> Result<Self, Self::Error> {
+                Ok(U256 {
+                    high: 0,
+                    low: value.try_into()?,
+                })
+            }
+        }
+    };
+}
+
+impl_try_from_int!(i8);
+impl_try_from_int!(i16);
+impl_try_from_int!(i32);
+impl_try_from_int!(i64);
+impl_try_from_int!(i128);
+
+#[derive(Debug)]
+pub struct TryFromU256Error;
+
+impl Display for TryFromU256Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        "out of range u256 type conversion attempted".fmt(f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TryFromU256Error {}
+
+macro_rules! impl_try_from_u256 {
+    ($to:ty) => {
+        impl TryFrom<U256> for $to {
+            type Error = TryFromU256Error;
+
+            fn try_from(value: U256) -> Result<Self, Self::Error> {
+                if value.high != 0 {
+                    Err(TryFromU256Error)
+                } else {
+                    value.low.try_into().map_err(|_| TryFromU256Error)
+                }
+            }
+        }
+    };
+}
+
+impl_try_from_u256!(u8);
+impl_try_from_u256!(u16);
+impl_try_from_u256!(u32);
+impl_try_from_u256!(u64);
+impl_try_from_u256!(u128);
+impl_try_from_u256!(i8);
+impl_try_from_u256!(i16);
+impl_try_from_u256!(i32);
+impl_try_from_u256!(i64);
+impl_try_from_u256!(i128);

--- a/crates/starknet-types-core/src/u256/tests/from_dec_str.rs
+++ b/crates/starknet-types-core/src/u256/tests/from_dec_str.rs
@@ -209,7 +209,6 @@ fn test_from_dec_str_overflow_detection() {
     let overflow_test =
         "999999999999999999999999999999999999999999999999999999999999999999999999999999";
     let x = U256::from_dec_str(overflow_test);
-    println!("{:?}", x);
     assert!(matches!(x, Err(FromStrError::ValueTooBig)));
 }
 

--- a/crates/starknet-types-core/src/u256/tests/from_dec_str.rs
+++ b/crates/starknet-types-core/src/u256/tests/from_dec_str.rs
@@ -96,22 +96,29 @@ fn test_from_dec_str_maximum_allowed_value() {
     let result = U256::from_dec_str(max_u256_str).unwrap();
     assert_eq!(result.low(), u128::MAX);
     assert_eq!(result.high(), u128::MAX);
+
+    let max_u256_plus_one_str =
+        "115792089237316195423570985008687907853269984665640564039457584007913129639936";
+    assert!(matches!(
+        U256::from_dec_str(max_u256_plus_one_str),
+        Err(FromStrError::ValueTooBig)
+    ));
 }
 
 #[test]
-fn test_from_dec_str_value_too_big() {
+fn test_from_dec_str_too_long() {
     // Test 79 digits (too big)
     let too_big = "1157920892373161954235709850086879078532699846656405640394575840079131296399350";
     assert!(matches!(
         U256::from_dec_str(too_big),
-        Err(FromStrError::ValueTooBig)
+        Err(FromStrError::StringTooLong)
     ));
 
     // Test even longer string
     let very_long = "1".repeat(100);
     assert!(matches!(
         U256::from_dec_str(&very_long),
-        Err(FromStrError::ValueTooBig)
+        Err(FromStrError::StringTooLong)
     ));
 }
 
@@ -120,38 +127,38 @@ fn test_from_dec_str_invalid_characters_lower_only() {
     // Test invalid decimal characters
     assert!(matches!(
         U256::from_dec_str("123a"),
-        Err(FromStrError::Parse(_))
+        Err(FromStrError::Invalid)
     ));
 
     assert!(matches!(
         U256::from_dec_str("12.3"),
-        Err(FromStrError::Parse(_))
+        Err(FromStrError::Invalid)
     ));
 
     assert!(matches!(
         U256::from_dec_str("12-3"),
-        Err(FromStrError::Parse(_))
+        Err(FromStrError::Invalid)
     ));
 
     assert!(matches!(
         U256::from_dec_str("12+3"),
-        Err(FromStrError::Parse(_))
+        Err(FromStrError::Invalid)
     ));
 
     assert!(matches!(
         U256::from_dec_str("12 3"),
-        Err(FromStrError::Parse(_))
+        Err(FromStrError::Invalid)
     ));
 
     // Test characters outside 0-9 range
     assert!(matches!(
         U256::from_dec_str("12:3"), // ':' is ASCII 58, '0' is 48, so b':' - b'0' = 10
-        Err(FromStrError::Parse(_))
+        Err(FromStrError::Invalid)
     ));
 
     assert!(matches!(
         U256::from_dec_str("12/3"), // '/' is ASCII 47, '0' is 48, so b'/' - b'0' = 255 (wrapping)
-        Err(FromStrError::Parse(_))
+        Err(FromStrError::Invalid)
     ));
 }
 
@@ -184,9 +191,9 @@ fn test_from_dec_str_boundary_lengths() {
     assert!(result.low() > 0 || result.high() > 0);
 
     // Test exactly 38 digits (just under 39)
-    let digits_38 = "12345678901234567890123456789012345678";
+    let digits_38 = "340282366920938463463374607431768211455";
     let result = U256::from_dec_str(digits_38).unwrap();
-    assert_eq!(result.low(), 12345678901234567890123456789012345678u128);
+    assert_eq!(result.low(), 340282366920938463463374607431768211455u128);
     assert_eq!(result.high(), 0);
 
     // Test exactly 39 digits (boundary for manual parsing)
@@ -239,12 +246,12 @@ fn test_from_dec_str_parse_error_for_small_values() {
     // Test that invalid characters in small values (< 39 digits) return Parse error
     assert!(matches!(
         U256::from_dec_str("1234567890123456789012a"),
-        Err(FromStrError::Parse(_))
+        Err(FromStrError::Invalid)
     ));
 
     assert!(matches!(
         U256::from_dec_str("1234567890123456789012.8"),
-        Err(FromStrError::Parse(_))
+        Err(FromStrError::Invalid)
     ));
 }
 

--- a/crates/starknet-types-core/src/u256/tests/from_dec_str.rs
+++ b/crates/starknet-types-core/src/u256/tests/from_dec_str.rs
@@ -1,0 +1,268 @@
+use crate::u256::{FromStrError, U256};
+
+#[test]
+fn test_from_dec_str_zero_values() {
+    // Test "0"
+    let result = U256::from_dec_str("0").unwrap();
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 0);
+
+    // Test multiple zeros
+    let result = U256::from_dec_str("000").unwrap();
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 0);
+
+    let result = U256::from_dec_str("0000000000000000000000000000000000000000").unwrap();
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 0);
+}
+
+#[test]
+fn test_from_dec_str_invalid_empty_after_trimming() {
+    // Test empty string
+    assert!(matches!(U256::from_dec_str(""), Err(FromStrError::Invalid)));
+}
+
+#[test]
+fn test_from_dec_str_small_values() {
+    // Test single digit
+    let result = U256::from_dec_str("1").unwrap();
+    assert_eq!(result.low(), 1);
+    assert_eq!(result.high(), 0);
+
+    let result = U256::from_dec_str("9").unwrap();
+    assert_eq!(result.low(), 9);
+    assert_eq!(result.high(), 0);
+
+    // Test multiple digits
+    let result = U256::from_dec_str("123").unwrap();
+    assert_eq!(result.low(), 123);
+    assert_eq!(result.high(), 0);
+
+    let result = U256::from_dec_str("999").unwrap();
+    assert_eq!(result.low(), 999);
+    assert_eq!(result.high(), 0);
+}
+
+#[test]
+fn test_from_dec_str_max_u128_value() {
+    let max_u128_str = "340282366920938463463374607431768211455";
+    let result = U256::from_dec_str(max_u128_str).unwrap();
+    assert_eq!(result.low(), u128::MAX);
+    assert_eq!(result.high(), 0);
+
+    let max_u128_plus_one_str = "340282366920938463463374607431768211456";
+    let result = U256::from_dec_str(max_u128_plus_one_str).unwrap();
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 1);
+
+    let max_u128_plus_two_str = "340282366920938463463374607431768211457";
+    let result = U256::from_dec_str(max_u128_plus_two_str).unwrap();
+    assert_eq!(result.low(), 1);
+    assert_eq!(result.high(), 1);
+}
+
+#[test]
+fn test_from_dec_str_values_under_39_digits() {
+    // Test values with less than 39 digits (should only use low part)
+    let result = U256::from_dec_str("12345678901234567890123456789012345678").unwrap(); // 38 digits
+    assert_eq!(result.low(), 12345678901234567890123456789012345678u128);
+    assert_eq!(result.high(), 0);
+
+    // Test a smaller value
+    let result = U256::from_dec_str("1000000000000000000000000000000000000").unwrap(); // 37 digits
+    assert_eq!(result.low(), 1000000000000000000000000000000000000u128);
+    assert_eq!(result.high(), 0);
+}
+
+#[test]
+fn test_from_dec_str_values_39_digits_and_above() {
+    // Test 39 digits (should use manual parsing)
+    let result = U256::from_dec_str("123456789012345678901234567890123456789").unwrap(); // 39 digits
+                                                                                         // This should use the manual parsing logic
+    assert!(result.low() > 0 || result.high() > 0);
+
+    // Test a specific known value that exceeds u128::MAX
+    let result = U256::from_dec_str("340282366920938463463374607431768211456").unwrap(); // u128::MAX + 1
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 1);
+}
+
+#[test]
+fn test_from_dec_str_maximum_allowed_value() {
+    // Test maximum value for u256 (78 digits)
+    let max_u256_str =
+        "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+    let result = U256::from_dec_str(max_u256_str).unwrap();
+    assert_eq!(result.low(), u128::MAX);
+    assert_eq!(result.high(), u128::MAX);
+}
+
+#[test]
+fn test_from_dec_str_value_too_big() {
+    // Test 79 digits (too big)
+    let too_big = "1157920892373161954235709850086879078532699846656405640394575840079131296399350";
+    assert!(matches!(
+        U256::from_dec_str(too_big),
+        Err(FromStrError::ValueTooBig)
+    ));
+
+    // Test even longer string
+    let very_long = "1".repeat(100);
+    assert!(matches!(
+        U256::from_dec_str(&very_long),
+        Err(FromStrError::ValueTooBig)
+    ));
+}
+
+#[test]
+fn test_from_dec_str_invalid_characters_lower_only() {
+    // Test invalid decimal characters
+    assert!(matches!(
+        U256::from_dec_str("123a"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    assert!(matches!(
+        U256::from_dec_str("12.3"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    assert!(matches!(
+        U256::from_dec_str("12-3"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    assert!(matches!(
+        U256::from_dec_str("12+3"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    assert!(matches!(
+        U256::from_dec_str("12 3"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    // Test characters outside 0-9 range
+    assert!(matches!(
+        U256::from_dec_str("12:3"), // ':' is ASCII 58, '0' is 48, so b':' - b'0' = 10
+        Err(FromStrError::Parse(_))
+    ));
+
+    assert!(matches!(
+        U256::from_dec_str("12/3"), // '/' is ASCII 47, '0' is 48, so b'/' - b'0' = 255 (wrapping)
+        Err(FromStrError::Parse(_))
+    ));
+}
+
+#[test]
+fn test_from_dec_str_leading_zeros() {
+    // Test leading zeros that should be trimmed
+    let result =
+        U256::from_dec_str("0000000000000000000000000000000000000000000000000000000000000001")
+            .unwrap();
+    assert_eq!(result.low(), 1);
+    assert_eq!(result.high(), 0);
+
+    let result =
+        U256::from_dec_str("00000000000000000000000000000000000000000000000000000000000000123")
+            .unwrap();
+    assert_eq!(result.low(), 123);
+    assert_eq!(result.high(), 0);
+
+    // Test case where all characters are zeros
+    let result = U256::from_dec_str("00000000000000000000000000000000").unwrap();
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 0);
+}
+
+#[test]
+fn test_from_dec_str_boundary_lengths() {
+    // Test exactly 78 digits (maximum allowed)
+    let max_78 = "111456789012345678901234567890123456789012345678901234567890123456789012345678";
+    let result = U256::from_dec_str(max_78).unwrap();
+    assert!(result.low() > 0 || result.high() > 0);
+
+    // Test exactly 38 digits (just under 39)
+    let digits_38 = "12345678901234567890123456789012345678";
+    let result = U256::from_dec_str(digits_38).unwrap();
+    assert_eq!(result.low(), 12345678901234567890123456789012345678u128);
+    assert_eq!(result.high(), 0);
+
+    // Test exactly 39 digits (boundary for manual parsing)
+    let digits_39 = "123456789012345678901234567890123456789";
+    let result = U256::from_dec_str(digits_39).unwrap();
+    assert!(result.low() > 0 || result.high() > 0);
+}
+
+#[test]
+fn test_from_dec_str_overflow_detection() {
+    // Test values that would cause overflow during manual parsing
+    // This tests the overflow detection in the multiplication and addition steps
+
+    // Test a value that's close to but not exceeding the limit
+    let near_max = "115792089237316195423570985008687907853269984665640564039457584007913129639934";
+    let result = U256::from_dec_str(near_max).unwrap();
+    assert!(result.low() > 0 || result.high() > 0);
+
+    // Test a value that would exceed u256 during intermediate calculations
+    let overflow_test =
+        "999999999999999999999999999999999999999999999999999999999999999999999999999999";
+    let x = U256::from_dec_str(overflow_test);
+    println!("{:?}", x);
+    assert!(matches!(x, Err(FromStrError::ValueTooBig)));
+}
+
+#[test]
+fn test_from_dec_str_specific_known_values() {
+    // Test some specific known values to verify correctness
+
+    // Test 10^38 (should use manual parsing)
+    let ten_to_38 = "100000000000000000000000000000000000000"; // 1 followed by 38 zeros
+    let result = U256::from_dec_str(ten_to_38).unwrap();
+    assert!(result.low() > 0 || result.high() > 0);
+
+    // Test 2^128 (should be high=1, low=0)
+    let two_to_128 = "340282366920938463463374607431768211456"; // 2^128
+    let result = U256::from_dec_str(two_to_128).unwrap();
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 1);
+
+    // Test 2^64
+    let two_to_64 = "18446744073709551616"; // 2^64
+    let result = U256::from_dec_str(two_to_64).unwrap();
+    assert_eq!(result.low(), 18446744073709551616u128);
+    assert_eq!(result.high(), 0);
+}
+
+#[test]
+fn test_from_dec_str_parse_error_for_small_values() {
+    // Test that invalid characters in small values (< 39 digits) return Parse error
+    assert!(matches!(
+        U256::from_dec_str("1234567890123456789012a"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    assert!(matches!(
+        U256::from_dec_str("1234567890123456789012.8"),
+        Err(FromStrError::Parse(_))
+    ));
+}
+
+#[test]
+fn test_from_dec_str_parse_error_for_big_values() {
+    // Test that invalid characters in small values (< 39 digits) return Parse error
+    assert!(matches!(
+        U256::from_dec_str(
+            "11579208923731619542357098500868790785326998466564056403945758400791312963993a"
+        ),
+        Err(FromStrError::Invalid)
+    ));
+
+    assert!(matches!(
+        U256::from_dec_str(
+            "11579208923731619542357098500868790785326998466564056403945758400791312963993 "
+        ),
+        Err(FromStrError::Invalid)
+    ));
+}

--- a/crates/starknet-types-core/src/u256/tests/from_hex_str.rs
+++ b/crates/starknet-types-core/src/u256/tests/from_hex_str.rs
@@ -133,25 +133,26 @@ fn test_from_hex_str_values_requiring_high() {
 }
 
 #[test]
-fn test_from_hex_str_value_too_big() {
+fn test_from_hex_str_too_long() {
     // Test 65 hex chars (too big)
     let too_big = "0x1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
     assert!(matches!(
         U256::from_hex_str(too_big),
-        Err(FromStrError::ValueTooBig)
+        Err(FromStrError::StringTooLong)
     ));
 
     // Test without prefix
+    let too_big = "1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
     assert!(matches!(
         U256::from_hex_str(too_big),
-        Err(FromStrError::ValueTooBig)
+        Err(FromStrError::StringTooLong)
     ));
 
     // Test even longer string
     let very_long = "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
     assert!(matches!(
         U256::from_hex_str(very_long),
-        Err(FromStrError::ValueTooBig)
+        Err(FromStrError::StringTooLong)
     ));
 }
 

--- a/crates/starknet-types-core/src/u256/tests/from_hex_str.rs
+++ b/crates/starknet-types-core/src/u256/tests/from_hex_str.rs
@@ -70,13 +70,14 @@ fn test_from_hex_str_small_values() {
 #[test]
 fn test_from_hex_str_max_low_value() {
     // Test maximum u128 value (32 hex chars)
-    let max_u128_hex = format!("{:x}", u128::MAX);
-    let result = U256::from_hex_str(&format!("0x{}", max_u128_hex)).unwrap();
+    let max_u128_hex = "ffffffffffffffffffffffffffffffff";
+    let result = U256::from_hex_str(max_u128_hex).unwrap();
     assert_eq!(result.low(), u128::MAX);
     assert_eq!(result.high(), 0);
 
     // Test without prefix
-    let result = U256::from_hex_str(&max_u128_hex).unwrap();
+    let max_u128_hex = "0xffffffffffffffffffffffffffffffff";
+    let result = U256::from_hex_str(max_u128_hex).unwrap();
     assert_eq!(result.low(), u128::MAX);
     assert_eq!(result.high(), 0);
 }
@@ -96,19 +97,20 @@ fn test_from_hex_str_values_requiring_high() {
     assert_eq!(result.high(), 1);
 
     // Test maximum value (64 hex chars)
-    let max_hex = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-    let result = U256::from_hex_str(&format!("0x{}", max_hex)).unwrap();
+    let max_hex = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    let result = U256::from_hex_str(max_hex).unwrap();
     assert_eq!(result.low(), u128::MAX);
     assert_eq!(result.high(), u128::MAX);
 
     // Test maximum value (64 hex chars) with leading zeros
-    let result = U256::from_hex_str(&format!("0x000000000000000{}", max_hex)).unwrap();
+    let max_hex = "0x0000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    let result = U256::from_hex_str(max_hex).unwrap();
     assert_eq!(result.low(), u128::MAX);
     assert_eq!(result.high(), u128::MAX);
 
     // Test 64 chars (maximum allowed)
-    let max_64 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    let result = U256::from_hex_str(&format!("0x{}", max_64)).unwrap();
+    let max_64 = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let result = U256::from_hex_str(max_64).unwrap();
     assert_eq!(
         result.high(),
         u128::from_str_radix("0123456789abcdef0123456789abcdef", 16).unwrap()
@@ -119,8 +121,8 @@ fn test_from_hex_str_values_requiring_high() {
     );
 
     // Test a 40-character hex string to verify correct splitting
-    let hex_40 = "1234567890abcdef1234567890abcdef12345678";
-    let result = U256::from_hex_str(&format!("0x{}", hex_40)).unwrap();
+    let hex_40 = "0x1234567890abcdef1234567890abcdef12345678";
+    let result = U256::from_hex_str(hex_40).unwrap();
 
     // Should split at position 8 (40 - 32 = 8)
     let expected_high = u128::from_str_radix("12345678", 16).unwrap();
@@ -133,9 +135,9 @@ fn test_from_hex_str_values_requiring_high() {
 #[test]
 fn test_from_hex_str_value_too_big() {
     // Test 65 hex chars (too big)
-    let too_big = "1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    let too_big = "0x1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
     assert!(matches!(
-        U256::from_hex_str(&format!("0x{}", too_big)),
+        U256::from_hex_str(too_big),
         Err(FromStrError::ValueTooBig)
     ));
 
@@ -146,9 +148,9 @@ fn test_from_hex_str_value_too_big() {
     ));
 
     // Test even longer string
-    let very_long = "1".repeat(100);
+    let very_long = "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
     assert!(matches!(
-        U256::from_hex_str(&format!("0x{}", very_long)),
+        U256::from_hex_str(very_long),
         Err(FromStrError::ValueTooBig)
     ));
 }

--- a/crates/starknet-types-core/src/u256/tests/from_hex_str.rs
+++ b/crates/starknet-types-core/src/u256/tests/from_hex_str.rs
@@ -1,0 +1,221 @@
+use crate::u256::{FromStrError, U256};
+
+#[test]
+fn test_from_hex_str_zero_values() {
+    // Test "0x0"
+    let result = U256::from_hex_str("0x0").unwrap();
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 0);
+
+    // Test "0X0" (uppercase prefix)
+    let result = U256::from_hex_str("0X0").unwrap();
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 0);
+
+    // Test "0" (no prefix)
+    let result = U256::from_hex_str("0").unwrap();
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 0);
+
+    // Test multiple zeros with prefix
+    let result = U256::from_hex_str("0x000").unwrap();
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 0);
+
+    // Test multiple zeros without prefix
+    let result = U256::from_hex_str("000").unwrap();
+    assert_eq!(result.low(), 0);
+    assert_eq!(result.high(), 0);
+}
+
+#[test]
+fn test_from_hex_str_invalid_empty_after_prefix() {
+    // Test empty string after removing prefix and zeros
+    assert!(matches!(
+        U256::from_hex_str("0x"),
+        Err(FromStrError::Invalid)
+    ));
+
+    assert!(matches!(
+        U256::from_hex_str("0X"),
+        Err(FromStrError::Invalid)
+    ));
+}
+
+#[test]
+fn test_from_hex_str_small_values() {
+    // Test single digit
+    let result = U256::from_hex_str("0x1").unwrap();
+    assert_eq!(result.low(), 1);
+    assert_eq!(result.high(), 0);
+
+    let result = U256::from_hex_str("0xf").unwrap();
+    assert_eq!(result.low(), 15);
+    assert_eq!(result.high(), 0);
+
+    let result = U256::from_hex_str("0xF").unwrap();
+    assert_eq!(result.low(), 15);
+    assert_eq!(result.high(), 0);
+
+    // Test without prefix
+    let result = U256::from_hex_str("a").unwrap();
+    assert_eq!(result.low(), 10);
+    assert_eq!(result.high(), 0);
+
+    let result = U256::from_hex_str("A").unwrap();
+    assert_eq!(result.low(), 10);
+    assert_eq!(result.high(), 0);
+}
+
+#[test]
+fn test_from_hex_str_max_low_value() {
+    // Test maximum u128 value (32 hex chars)
+    let max_u128_hex = format!("{:x}", u128::MAX);
+    let result = U256::from_hex_str(&format!("0x{}", max_u128_hex)).unwrap();
+    assert_eq!(result.low(), u128::MAX);
+    assert_eq!(result.high(), 0);
+
+    // Test without prefix
+    let result = U256::from_hex_str(&max_u128_hex).unwrap();
+    assert_eq!(result.low(), u128::MAX);
+    assert_eq!(result.high(), 0);
+}
+
+#[test]
+fn test_from_hex_str_values_requiring_high() {
+    // Test 33 hex chars (should use high part)
+    let result = U256::from_hex_str("0x1ffffffffffffffffffffffffffffffff").unwrap();
+    assert_eq!(result.low(), u128::MAX);
+    assert_eq!(result.high(), 1);
+
+    // Test with leading zeros that get trimmed
+    let result =
+        U256::from_hex_str("0x00000000000000000000000000000001ffffffffffffffffffffffffffffffff")
+            .unwrap();
+    assert_eq!(result.low(), u128::MAX);
+    assert_eq!(result.high(), 1);
+
+    // Test maximum value (64 hex chars)
+    let max_hex = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    let result = U256::from_hex_str(&format!("0x{}", max_hex)).unwrap();
+    assert_eq!(result.low(), u128::MAX);
+    assert_eq!(result.high(), u128::MAX);
+
+    // Test maximum value (64 hex chars) with leading zeros
+    let result = U256::from_hex_str(&format!("0x000000000000000{}", max_hex)).unwrap();
+    assert_eq!(result.low(), u128::MAX);
+    assert_eq!(result.high(), u128::MAX);
+
+    // Test 64 chars (maximum allowed)
+    let max_64 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let result = U256::from_hex_str(&format!("0x{}", max_64)).unwrap();
+    assert_eq!(
+        result.high(),
+        u128::from_str_radix("0123456789abcdef0123456789abcdef", 16).unwrap()
+    );
+    assert_eq!(
+        result.low(),
+        u128::from_str_radix("0123456789abcdef0123456789abcdef", 16).unwrap()
+    );
+
+    // Test a 40-character hex string to verify correct splitting
+    let hex_40 = "1234567890abcdef1234567890abcdef12345678";
+    let result = U256::from_hex_str(&format!("0x{}", hex_40)).unwrap();
+
+    // Should split at position 8 (40 - 32 = 8)
+    let expected_high = u128::from_str_radix("12345678", 16).unwrap();
+    let expected_low = u128::from_str_radix("90abcdef1234567890abcdef12345678", 16).unwrap();
+
+    assert_eq!(result.high(), expected_high);
+    assert_eq!(result.low(), expected_low);
+}
+
+#[test]
+fn test_from_hex_str_value_too_big() {
+    // Test 65 hex chars (too big)
+    let too_big = "1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    assert!(matches!(
+        U256::from_hex_str(&format!("0x{}", too_big)),
+        Err(FromStrError::ValueTooBig)
+    ));
+
+    // Test without prefix
+    assert!(matches!(
+        U256::from_hex_str(too_big),
+        Err(FromStrError::ValueTooBig)
+    ));
+
+    // Test even longer string
+    let very_long = "1".repeat(100);
+    assert!(matches!(
+        U256::from_hex_str(&format!("0x{}", very_long)),
+        Err(FromStrError::ValueTooBig)
+    ));
+}
+
+#[test]
+fn test_from_hex_str_invalid_characters() {
+    // Test invalid hex characters
+    assert!(matches!(
+        U256::from_hex_str("0xg"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    assert!(matches!(
+        U256::from_hex_str("0x123g"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    assert!(matches!(
+        U256::from_hex_str("0xz"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    // Test without prefix
+    assert!(matches!(
+        U256::from_hex_str("g"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    assert!(matches!(
+        U256::from_hex_str("123g"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    // Test invalid characters in high part
+    assert!(matches!(
+        U256::from_hex_str("0xg123456789abcdef123456789abcdef12"),
+        Err(FromStrError::Parse(_))
+    ));
+
+    // Test invalid characters in low part when high part is present
+    assert!(matches!(
+        U256::from_hex_str("0x1123456789abcdef123456789abcdefg2"),
+        Err(FromStrError::Parse(_))
+    ));
+}
+
+#[test]
+fn test_from_hex_str_mixed_case() {
+    // Test mixed case hex digits
+    let result = U256::from_hex_str("0xaBcDeF123456789").unwrap();
+    assert_eq!(
+        result.low(),
+        u128::from_str_radix("aBcDeF123456789", 16).unwrap()
+    );
+    assert_eq!(result.high(), 0);
+
+    // Test mixed case in both parts
+    let result = U256::from_hex_str("0xaBcDeF123456789aBcDeF123456789aBcDeF12").unwrap();
+    assert_eq!(result.high(), u128::from_str_radix("aBcDeF", 16).unwrap());
+    assert_eq!(
+        result.low(),
+        u128::from_str_radix("123456789aBcDeF123456789aBcDeF12", 16).unwrap()
+    );
+}
+
+#[test]
+fn test_from_hex_str_empty_string() {
+    // Test empty string
+    assert!(matches!(U256::from_hex_str(""), Err(FromStrError::Invalid)));
+}

--- a/crates/starknet-types-core/src/u256/tests/mod.rs
+++ b/crates/starknet-types-core/src/u256/tests/mod.rs
@@ -1,0 +1,88 @@
+use core::str::FromStr;
+
+use crate::felt::{Felt, PrimitiveFromFeltError};
+
+use super::U256;
+
+mod from_dec_str;
+mod from_hex_str;
+
+#[test]
+fn from_parts() {
+    let value = U256::from_parts(0x2, 0x1);
+    assert_eq!(value.low(), 0x1);
+    assert_eq!(value.high(), 0x2);
+    assert_eq!(value.low, 0x1);
+    assert_eq!(value.high, 0x2);
+}
+
+#[test]
+fn try_from_felt_parts() {
+    let u128_max = Felt::from(u128::MAX);
+    let u128_max_plus_one = u128_max + 1;
+
+    assert!(U256::try_from_felt_parts(u128_max, u128_max).is_ok());
+    assert!(matches!(
+        U256::try_from_felt_parts(u128_max, u128_max_plus_one),
+        Err(PrimitiveFromFeltError)
+    ));
+    assert!(matches!(
+        U256::try_from_felt_parts(Felt::MAX, u128_max),
+        Err(PrimitiveFromFeltError)
+    ));
+}
+
+#[test]
+fn try_from_dec_str_parts() {
+    let valid_str = "123";
+    assert!(U256::try_from_dec_str_parts(valid_str, valid_str).is_ok());
+
+    let invalid_str = "";
+    assert!(U256::try_from_dec_str_parts(valid_str, invalid_str).is_err());
+    let invalid_str = "10p";
+    assert!(U256::try_from_dec_str_parts(invalid_str, valid_str).is_err());
+    let invalid_str = "0x123";
+    assert!(U256::try_from_dec_str_parts(invalid_str, valid_str).is_err());
+}
+#[test]
+fn try_from_hex_str_parts() {
+    let valid_str = "123";
+    assert!(U256::try_from_hex_str_parts(valid_str, valid_str).is_ok());
+
+    let valid_str = "0X123";
+    let invalid_str = "";
+    assert!(U256::try_from_hex_str_parts(valid_str, invalid_str).is_err());
+    let invalid_str = "10p";
+    assert!(U256::try_from_hex_str_parts(invalid_str, valid_str).is_err());
+    let invalid_str = "0x0x123";
+    assert!(U256::try_from_hex_str_parts(invalid_str, valid_str).is_err());
+}
+
+#[test]
+fn from_str() {
+    let input = "0x1234";
+    assert_eq!(
+        U256::from_str(input).unwrap(),
+        U256::from_hex_str(input).unwrap()
+    );
+    let input = "0X1234";
+    assert_eq!(
+        U256::from_str(input).unwrap(),
+        U256::from_hex_str(input).unwrap()
+    );
+    let input = "1234";
+    assert_eq!(
+        U256::from_str(input).unwrap(),
+        U256::from_dec_str(input).unwrap()
+    );
+    let input = "1234ff";
+    assert!(U256::from_str(input).is_err());
+}
+
+#[test]
+fn ordering() {
+    let value1 = U256::from_parts(2, 1);
+    let value2 = U256::from_parts(1, 3);
+    assert!(value2 < value1);
+    assert_eq!(value2, value2);
+}

--- a/crates/starknet-types-core/src/u256/tests/mod.rs
+++ b/crates/starknet-types-core/src/u256/tests/mod.rs
@@ -95,3 +95,101 @@ fn ordering() {
     assert!(value2 < value1);
     assert_eq!(value2, value2);
 }
+
+#[test]
+fn from_primitives_impl() {
+    let value: U256 = u8::MAX.into();
+    assert_eq!(
+        value,
+        U256 {
+            high: 0,
+            low: u8::MAX.into()
+        }
+    );
+    let value: U256 = u16::MAX.into();
+    assert_eq!(
+        value,
+        U256 {
+            high: 0,
+            low: u16::MAX.into()
+        }
+    );
+    let value: U256 = u32::MAX.into();
+    assert_eq!(
+        value,
+        U256 {
+            high: 0,
+            low: u32::MAX.into()
+        }
+    );
+    let value: U256 = u64::MAX.into();
+    assert_eq!(
+        value,
+        U256 {
+            high: 0,
+            low: u64::MAX.into()
+        }
+    );
+    let value: U256 = u128::MAX.into();
+    assert_eq!(
+        value,
+        U256 {
+            high: 0,
+            low: u128::MAX
+        }
+    );
+
+    // Try from positive signed values
+    let value: U256 = i8::MAX.try_into().unwrap();
+    assert_eq!(
+        value,
+        U256 {
+            high: 0,
+            low: i8::MAX.try_into().unwrap()
+        }
+    );
+    let value: U256 = i16::MAX.try_into().unwrap();
+    assert_eq!(
+        value,
+        U256 {
+            high: 0,
+            low: i16::MAX.try_into().unwrap()
+        }
+    );
+    let value: U256 = i32::MAX.try_into().unwrap();
+    assert_eq!(
+        value,
+        U256 {
+            high: 0,
+            low: i32::MAX.try_into().unwrap()
+        }
+    );
+    let value: U256 = i64::MAX.try_into().unwrap();
+    assert_eq!(
+        value,
+        U256 {
+            high: 0,
+            low: i64::MAX.try_into().unwrap()
+        }
+    );
+    let value: U256 = i128::MAX.try_into().unwrap();
+    assert_eq!(
+        value,
+        U256 {
+            high: 0,
+            low: i128::MAX.try_into().unwrap()
+        }
+    );
+
+    // Try from negative values
+    let res = U256::try_from(i8::MIN);
+    assert!(res.is_err());
+    let res = U256::try_from(i16::MIN);
+    assert!(res.is_err());
+    let res = U256::try_from(i32::MIN);
+    assert!(res.is_err());
+    let res = U256::try_from(i64::MIN);
+    assert!(res.is_err());
+    let res = U256::try_from(i128::MIN);
+    assert!(res.is_err());
+}

--- a/crates/starknet-types-core/src/u256/tests/mod.rs
+++ b/crates/starknet-types-core/src/u256/tests/mod.rs
@@ -36,6 +36,9 @@ fn try_from_felt_parts() {
 fn try_from_dec_str_parts() {
     let valid_str = "123";
     assert!(U256::try_from_dec_str_parts(valid_str, valid_str).is_ok());
+    let valid_str =
+        "00000000000000000000000000000000000000000000000000000000000000000000000000000000000123";
+    assert!(U256::try_from_dec_str_parts(valid_str, valid_str).is_ok());
 
     let invalid_str = "";
     assert!(U256::try_from_dec_str_parts(valid_str, invalid_str).is_err());
@@ -48,8 +51,12 @@ fn try_from_dec_str_parts() {
 fn try_from_hex_str_parts() {
     let valid_str = "123";
     assert!(U256::try_from_hex_str_parts(valid_str, valid_str).is_ok());
+    let valid_str = "0x123";
+    assert!(U256::try_from_hex_str_parts(valid_str, valid_str).is_ok());
+    let valid_str =
+        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000123";
+    assert!(U256::try_from_hex_str_parts(valid_str, valid_str).is_ok());
 
-    let valid_str = "0X123";
     let invalid_str = "";
     assert!(U256::try_from_hex_str_parts(valid_str, invalid_str).is_err());
     let invalid_str = "10p";
@@ -76,6 +83,8 @@ fn from_str() {
         U256::from_dec_str(input).unwrap()
     );
     let input = "1234ff";
+    assert!(U256::from_str(input).is_err());
+    let input = "0x0x1";
     assert!(U256::from_str(input).is_err());
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Add a U256 type, following its cairo representation as two u128 (high and low), along with some utility functions to build those, usefull traits impl.


## What is the new behavior?

This struct purpose is not to do any arithmetic on u256. For this, you should convert it to your own mathematically equipped u256 type. 
It acts more as a useful intermediate representation for any display, serialization, or parsing work of cairo-represented u256 you may have to do.


## Does this introduce a breaking change?

No.

## To be discussed

Should I implement From/Into logic in regard to the major u256 types here (from crates primitive-types, uint, ...)?
