### PR TITLE
Enforce hash feature to support no_std

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -18,7 +18,7 @@ num-integer = { version = "0.1", default-features = false }
 
 # Optional
 arbitrary = { version = "1.3", optional = true }
-blake2 = { version = "0.10.6", optional = true }
+blake2 = { version = "0.10.6", default-features = false, optional = true }
 digest = { version = "0.10.7", optional = true }
 serde = { version = "1", optional = true, default-features = false, features = [
   "alloc",
@@ -52,7 +52,10 @@ papyrus-serialization = ["std"]
 zeroize = ["dep:zeroize"]
 
 [dev-dependencies]
-proptest = { version = "1.5", default-features = false, features = ["alloc", "proptest-macro"] }
+proptest = { version = "1.5", default-features = false, features = [
+  "alloc",
+  "proptest-macro",
+] }
 regex = "1.11"
 serde_test = "1"
 criterion = "0.5"

--- a/ensure_no_std/Cargo.toml
+++ b/ensure_no_std/Cargo.toml
@@ -10,6 +10,7 @@ starknet-types-core = { path = "../crates/starknet-types-core", default-features
     "curve",
     "parity-scale-codec",
     "num-traits",
+    "hash",
 ] }
 wee_alloc = "0.4.5"
 


### PR DESCRIPTION
# Pull Request type

Bugfix

## What is the current behavior?

Using `starknet-types-core` 0.1.9 with `hash` feature disables `no_std` support.

## What is the new behavior?

Libraries and binaries can depend on `starknet-types-core` 0.1.9 with `hash` feature while keeping `no_std` support.

- Adds `hash` feature in `ensure_no_std` crate to enforce `no_std` check.
- Disable default features of `blake2` dependency to keep `no_std` support in `starknet-types-core` 0.1.9.

## Does this introduce a breaking change?

No
