### PR TITLE
fix(felt): full `fmt` specs implem

### DIFF
--- a/crates/starknet-types-core/src/felt/alloc_impls.rs
+++ b/crates/starknet-types-core/src/felt/alloc_impls.rs
@@ -21,12 +21,7 @@ impl Felt {
     /// The resulting string is guaranted to be 66 chars long, which is enough to represent `Felt::MAX`:
     /// 2 chars for the `0x` prefix and 64 chars for the padded hexadecimal felt value.
     pub fn to_fixed_hex_string(&self) -> alloc::string::String {
-        let hex_str = alloc::format!("{self:#x}");
-        if hex_str.len() < 66 {
-            alloc::format!("0x{:0>64}", hex_str.strip_prefix("0x").unwrap())
-        } else {
-            hex_str
-        }
+        alloc::format!("{self:#066x}")
     }
 }
 
@@ -35,22 +30,7 @@ impl fmt::LowerHex for Felt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let hex = alloc::string::ToString::to_string(&self.0);
         let hex = hex.strip_prefix("0x").unwrap();
-
-        let width = if f.sign_aware_zero_pad() {
-            f.width().unwrap().min(64)
-        } else {
-            1
-        };
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-
-        if hex.len() < width {
-            for _ in 0..(width - hex.len()) {
-                write!(f, "0")?;
-            }
-        }
-        write!(f, "{}", hex)
+        f.pad_integral(true, if f.alternate() { "0x" } else { "" }, hex)
     }
 }
 
@@ -59,22 +39,7 @@ impl fmt::UpperHex for Felt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let hex = alloc::string::ToString::to_string(&self.0);
         let hex = hex.strip_prefix("0x").unwrap().to_uppercase();
-
-        let width = if f.sign_aware_zero_pad() {
-            f.width().unwrap().min(64)
-        } else {
-            1
-        };
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-
-        if hex.len() < width {
-            for _ in 0..(width - hex.len()) {
-                write!(f, "0")?;
-            }
-        }
-        write!(f, "{}", hex)
+        f.pad_integral(true, if f.alternate() { "0x" } else { "" }, &hex)
     }
 }
 


### PR DESCRIPTION
Fixes #124 

## What is the current behavior?

The following (valid) format pattern causes a panic.

```rust
 let x = Felt::from_hex_unchecked("0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d");
println!("{:#0x}", x);
```
This is due to a homemade, incomplete implementation of the rust [formatting specs](https://doc.rust-lang.org/std/fmt/#sign0).

## What is the new behavior?

We don't panic.
We follow the specs (space padding, 0 padding).

## Does this introduce a breaking change?

Yes. Maximum width was previously constrained to 66. Giving a bigger value would still result in a 66 chars len string.
This constraint is now raised.
Space padding was ignored ( `println!("{:5x}", Felt::ONE);` resulted in `1` instead of `    1`). It is now working.

## Additional comments

The new impl leverages the Rust standard library methods already available for formatting.

