### PR TITLE
Bump Lambdaworks to 0.12.0

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -11,7 +11,7 @@ description = "Core types representation for Starknet"
 readme = "README.md"
 
 [dependencies]
-lambdaworks-math = { version = "0.10.0", default-features = false }
+lambdaworks-math = { version = "0.12.0", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
 num-integer = { version = "0.1", default-features = false }
@@ -23,7 +23,7 @@ digest = { version = "0.10.7", optional = true }
 serde = { version = "1", optional = true, default-features = false, features = [
   "alloc", "derive"
 ] }
-lambdaworks-crypto = { version = "0.10.0", default-features = false, optional = true }
+lambdaworks-crypto = { version = "0.12.0", default-features = false, optional = true }
 parity-scale-codec = { version = "3.6", default-features = false, optional = true }
 lazy_static = { version = "1.5", default-features = false, optional = true }
 zeroize = { version = "1.8.1", default-features = false, optional = true }

--- a/crates/starknet-types-core/src/curve/affine_point.rs
+++ b/crates/starknet-types-core/src/curve/affine_point.rs
@@ -2,6 +2,7 @@ use crate::{curve::curve_errors::CurveError, felt::Felt};
 use lambdaworks_math::{
     cyclic_group::IsGroup,
     elliptic_curve::{
+        point::ProjectivePoint,
         short_weierstrass::{
             curves::stark_curve::StarkCurve, point::ShortWeierstrassProjectivePoint,
             traits::IsShortWeierstrass,
@@ -27,11 +28,12 @@ impl AffinePoint {
     /// This method should be used with caution, as it does not validate whether the provided coordinates
     /// correspond to a valid point on the curve.
     pub const fn new_unchecked(x: Felt, y: Felt) -> AffinePoint {
-        Self(ShortWeierstrassProjectivePoint::new([
+        Self(ShortWeierstrassProjectivePoint(ProjectivePoint::new([
             x.0,
             y.0,
             Felt::ONE.0,
-        ]))
+        ])))
+
     }
 
     /// Construct new affine point from the `x` coordinate and the parity bit `y_parity`.

--- a/crates/starknet-types-core/src/curve/projective_point.rs
+++ b/crates/starknet-types-core/src/curve/projective_point.rs
@@ -56,11 +56,9 @@ impl ProjectivePoint {
     /// This method should be used with caution, as it does not validate whether the provided coordinates
     /// correspond to a valid point on the curve.
     pub fn from_affine_unchecked(x: Felt, y: Felt) -> Self {
-        Self(ShortWeierstrassProjectivePoint::new([
-            x.0,
-            y.0,
-            Felt::ONE.0,
-        ]))
+        Self(ShortWeierstrassProjectivePoint(
+            LambdaworksProjectivePoint::new([x.0, y.0, Felt::ONE.0]),
+        ))
     }
 
     /// Returns the `x` coordinate of the point.

--- a/crates/starknet-types-core/src/curve/projective_point.rs
+++ b/crates/starknet-types-core/src/curve/projective_point.rs
@@ -3,6 +3,7 @@ use crate::curve::curve_errors::CurveError;
 use crate::felt::Felt;
 use core::ops;
 use lambdaworks_math::cyclic_group::IsGroup;
+use lambdaworks_math::elliptic_curve::point::ProjectivePoint as LambdaworksProjectivePoint;
 use lambdaworks_math::elliptic_curve::short_weierstrass::curves::stark_curve::StarkCurve;
 use lambdaworks_math::elliptic_curve::short_weierstrass::point::ShortWeierstrassProjectivePoint;
 use lambdaworks_math::elliptic_curve::traits::EllipticCurveError::InvalidPoint;
@@ -15,8 +16,10 @@ use lambdaworks_math::unsigned_integer::traits::IsUnsignedInteger;
 pub struct ProjectivePoint(pub(crate) ShortWeierstrassProjectivePoint<StarkCurve>);
 
 impl ProjectivePoint {
-    pub fn new(x: Felt, y: Felt, z: Felt) -> ProjectivePoint {
-        Self(ShortWeierstrassProjectivePoint::new([x.0, y.0, z.0]))
+    pub fn new_unchecked(x: Felt, y: Felt, z: Felt) -> ProjectivePoint {
+        Self(ShortWeierstrassProjectivePoint(
+            LambdaworksProjectivePoint::new([x.0, y.0, z.0]),
+        ))
     }
 
     /// The point at infinity.
@@ -201,7 +204,7 @@ mod test {
 
     #[test]
     fn try_from_affine() {
-        let projective_point = ProjectivePoint::new(
+        let projective_point = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "874739451078007766457464989774322083649278607533249481151382481072868806602",
             )
@@ -265,7 +268,7 @@ mod test {
         assert!(identity.is_identity());
         assert_eq!(
             identity,
-            ProjectivePoint::new(Felt::from(0), Felt::from(1), Felt::from(0))
+            ProjectivePoint::new_unchecked(Felt::from(0), Felt::from(1), Felt::from(0))
         );
 
         assert_eq!(
@@ -273,7 +276,7 @@ mod test {
             Err(CurveError::EllipticCurveError(InvalidPoint))
         );
 
-        let a = ProjectivePoint::new(
+        let a = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "874739451078007766457464989774322083649278607533249481151382481072868806602",
             )
@@ -290,7 +293,7 @@ mod test {
     #[test]
     // Results checked against starknet-rs https://github.com/xJonathanLEI/starknet-rs/
     fn add_operations() {
-        let projective_point_1 = ProjectivePoint::new(
+        let projective_point_1 = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "874739451078007766457464989774322083649278607533249481151382481072868806602",
             )
@@ -325,7 +328,7 @@ mod test {
     #[test]
     // Results checked against starknet-rs https://github.com/xJonathanLEI/starknet-rs/
     fn add_operations_with_affine() {
-        let projective_point = ProjectivePoint::new(
+        let projective_point = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "874739451078007766457464989774322083649278607533249481151382481072868806602",
             )
@@ -358,7 +361,7 @@ mod test {
     #[test]
     // Results checked against starknet-rs https://github.com/xJonathanLEI/starknet-rs/
     fn add_operations_with_affine_no_pointer() {
-        let projective_point = ProjectivePoint::new(
+        let projective_point = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "874739451078007766457464989774322083649278607533249481151382481072868806602",
             )
@@ -391,7 +394,7 @@ mod test {
     #[test]
     // Results checked against starknet-rs https://github.com/xJonathanLEI/starknet-rs/
     fn add_assign_operations() {
-        let mut projective_point_1 = ProjectivePoint::new(
+        let mut projective_point_1 = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "874739451078007766457464989774322083649278607533249481151382481072868806602",
             )
@@ -427,7 +430,7 @@ mod test {
     #[test]
     // Results checked against starknet-rs https://github.com/xJonathanLEI/starknet-rs/
     fn add_assign_operations_with_affine() {
-        let mut projective_point = ProjectivePoint::new(
+        let mut projective_point = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "874739451078007766457464989774322083649278607533249481151382481072868806602",
             )
@@ -463,7 +466,7 @@ mod test {
     #[test]
     // Results checked against starknet-rs https://github.com/xJonathanLEI/starknet-rs/
     fn add_assign_operations_with_affine_no_pointer() {
-        let mut projective_point = ProjectivePoint::new(
+        let mut projective_point = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "874739451078007766457464989774322083649278607533249481151382481072868806602",
             )
@@ -507,7 +510,7 @@ mod test {
             identity
         );
 
-        let projective_point_1 = ProjectivePoint::new(
+        let projective_point_1 = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "685118385380464480289795596422487144864558069280897344382334516257395969277",
             )
@@ -539,7 +542,7 @@ mod test {
 
     #[test]
     fn mul_by_scalar_operations_with_felt() {
-        let a = ProjectivePoint::new(
+        let a = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "685118385380464480289795596422487144864558069280897344382334516257395969277",
             )
@@ -564,7 +567,7 @@ mod test {
     #[test]
     // Results checked against starknet-rs https://github.com/xJonathanLEI/starknet-rs/
     fn double_operations() {
-        let projective_point = ProjectivePoint::new(
+        let projective_point = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "874739451078007766457464989774322083649278607533249481151382481072868806602",
             )
@@ -594,7 +597,7 @@ mod test {
 
     #[test]
     fn neg_operations() {
-        let a = ProjectivePoint::new(
+        let a = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "685118385380464480289795596422487144864558069280897344382334516257395969277",
             )
@@ -606,7 +609,7 @@ mod test {
             Felt::from(1),
         );
 
-        let b = ProjectivePoint::new(
+        let b = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "685118385380464480289795596422487144864558069280897344382334516257395969277",
             )
@@ -623,7 +626,7 @@ mod test {
 
     #[test]
     fn sub_operations_pointers() {
-        let mut a = ProjectivePoint::new(
+        let mut a = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "685118385380464480289795596422487144864558069280897344382334516257395969277",
             )
@@ -645,7 +648,7 @@ mod test {
 
     #[test]
     fn sub_operations() {
-        let mut a = ProjectivePoint::new(
+        let mut a = ProjectivePoint::new_unchecked(
             Felt::from_dec_str(
                 "685118385380464480289795596422487144864558069280897344382334516257395969277",
             )

--- a/crates/starknet-types-core/src/curve/projective_point.rs
+++ b/crates/starknet-types-core/src/curve/projective_point.rs
@@ -16,6 +16,10 @@ use lambdaworks_math::unsigned_integer::traits::IsUnsignedInteger;
 pub struct ProjectivePoint(pub(crate) ShortWeierstrassProjectivePoint<StarkCurve>);
 
 impl ProjectivePoint {
+    pub fn new(x: Felt, y: Felt, z: Felt) -> Result<ProjectivePoint, CurveError> {
+        Ok(Self(ShortWeierstrassProjectivePoint::new([x.0, y.0, z.0])?))
+    }
+
     pub fn new_unchecked(x: Felt, y: Felt, z: Felt) -> ProjectivePoint {
         Self(ShortWeierstrassProjectivePoint(
             LambdaworksProjectivePoint::new([x.0, y.0, z.0]),

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -235,7 +235,7 @@ impl Felt {
 
     /// Finite field division.
     pub fn field_div(&self, rhs: &NonZeroFelt) -> Self {
-        Self(self.0 / rhs.0)
+        Self((self.0 / rhs.0).expect("dividing by a non zero felt will never fail"))
     }
 
     /// Truncated quotient between `self` and `rhs`.


### PR DESCRIPTION
Bumps Lambdaworks to 0.12.0.

[Lambdaworks 0.11.0](https://github.com/lambdaclass/lambdaworks/releases/tag/v0.11.0) added support for the degree-4 extension of the Mersenne 31 field. By bumping Lambdaworks, we could reuse the math primitives instead of implementing them manually. Related to #149.

# Pull Request type

Chore

## What is the current behavior?

We are using currently Lambdaworks 0.10.0.

## What is the new behavior?

Use lambdaworks 0.12.0 instead.

I had to change the implementation of some functions because the new version of Lambdaworks returns more errors than before.

## Does this introduce a breaking change?

Yes.

Building a `ShortWeierstrassProjectivePoint` may fail, So I added a new function `new_unchecked` which does not return a result, while `new` does (the signature of `new` changed).
