### PR TITLE
feat: improve non-human-readable felt serialization space efficiency

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -66,6 +66,7 @@ rand_chacha = "0.9"
 rand = "0.9.2"
 rstest = "0.24"
 lazy_static = { version = "1.5", default-features = false }
+bincode = "1"
 
 [[bench]]
 name = "criterion_hashes"

--- a/crates/starknet-types-core/src/felt/serde.rs
+++ b/crates/starknet-types-core/src/felt/serde.rs
@@ -84,6 +84,7 @@ impl de::Visitor<'_> for FeltVisitor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bincode::Options;
     use proptest::prelude::*;
     use serde_test::{assert_tokens, Configure, Token};
 
@@ -119,6 +120,20 @@ mod tests {
             &Felt::from_hex_unchecked("0xbabe0000").compact(),
             &[Token::Bytes(&[0xba, 0xbe, 0, 0])],
         );
+    }
+
+    #[test]
+    fn backward_compatible_deserialization() {
+        static TWO_SERIALIZED_USING_PREVIOUS_IMPLEMENTATION: [u8; 33] = [
+            32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 2,
+        ];
+
+        let options = bincode::DefaultOptions::new();
+        let deserialized = options
+            .deserialize(&TWO_SERIALIZED_USING_PREVIOUS_IMPLEMENTATION)
+            .unwrap();
+        assert_eq!(Felt::TWO, deserialized);
     }
 
     proptest! {


### PR DESCRIPTION

## What is the current behavior?

When serialized in a non-human-readable format, the full 32 bytes of the felt are serialized, which means the value `zero` is represented as its len `32` followed by  32 `0`. Which means 33 byte.ss in total. This is a huge waste of space and bandwidth.


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- all leading zeros are ignored. `Felt::ZERO` becomes `&[1, 0]` ([len, value]), 2 bytes

## Does this introduce a breaking change?

YES. 
Values are serialized in the different way.
But possible bugs are mitigated by the fact that the deserialization of values is backward compatible: values serialized using the previous implementation can still be deserialized using the current one.
This means if you stored a serialized value somewhere (db, file) or if you are interacting with a service that has not updated to the new implementation, no bug will occur if you just do serialization/deserialization.
Bugs will only happen if you have some expectation about the serialized array always being 32 bytes long. Which some libs like ` bincode` do have.
So definitely a breaking change there

