### PR TITLE
Downgrade Lambdaworks to 0.11.0

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -11,7 +11,7 @@ description = "Core types representation for Starknet"
 readme = "README.md"
 
 [dependencies]
-lambdaworks-math = { version = "0.12.0", default-features = false }
+lambdaworks-math = { version = "0.11.0", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
 num-integer = { version = "0.1", default-features = false }
@@ -23,7 +23,7 @@ digest = { version = "0.10.7", optional = true }
 serde = { version = "1", optional = true, default-features = false, features = [
     "alloc", "derive"
 ] }
-lambdaworks-crypto = { version = "0.12.0", default-features = false, optional = true }
+lambdaworks-crypto = { version = "0.11.0", default-features = false, optional = true }
 parity-scale-codec = { version = "3.6", default-features = false, optional = true }
 lazy_static = { version = "1.5", default-features = false, optional = true }
 zeroize = { version = "1.8.1", default-features = false, optional = true }

--- a/crates/starknet-types-core/src/curve/projective_point.rs
+++ b/crates/starknet-types-core/src/curve/projective_point.rs
@@ -17,6 +17,10 @@ pub struct ProjectivePoint(pub(crate) ShortWeierstrassProjectivePoint<StarkCurve
 
 impl ProjectivePoint {
     pub fn new(x: Felt, y: Felt, z: Felt) -> Result<ProjectivePoint, CurveError> {
+        // While this function returns a `Result` it will always return the `Ok` variant.
+        // v0.3.0 bumped lambdaworks from 0.10.0 to 0.12.0 but v0.3.1 downgraded it to 0.11.0
+        // so the idea is to preserve the API.
+        // This function should be simplified before releasing a major version (i.e. 0.4.0)
         Ok(Self(ShortWeierstrassProjectivePoint::new([x.0, y.0, z.0])))
     }
 

--- a/crates/starknet-types-core/src/curve/projective_point.rs
+++ b/crates/starknet-types-core/src/curve/projective_point.rs
@@ -17,7 +17,7 @@ pub struct ProjectivePoint(pub(crate) ShortWeierstrassProjectivePoint<StarkCurve
 
 impl ProjectivePoint {
     pub fn new(x: Felt, y: Felt, z: Felt) -> Result<ProjectivePoint, CurveError> {
-        Ok(Self(ShortWeierstrassProjectivePoint::new([x.0, y.0, z.0])?))
+        Ok(Self(ShortWeierstrassProjectivePoint::new([x.0, y.0, z.0])))
     }
 
     /// Creates a new short Weierstrass projective point, assuming the coordinates are valid.

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -234,7 +234,7 @@ impl Felt {
 
     /// Finite field division.
     pub fn field_div(&self, rhs: &NonZeroFelt) -> Self {
-        Self((self.0 / rhs.0).expect("dividing by a non zero felt will never fail"))
+        Self(self.0 / rhs.0)
     }
 
     /// Truncated quotient between `self` and `rhs`.

--- a/crates/starknet-types-core/src/qm31/mod.rs
+++ b/crates/starknet-types-core/src/qm31/mod.rs
@@ -11,7 +11,6 @@ use lambdaworks_math::field::{
         extensions::{Degree2ExtensionField, Degree4ExtensionField},
         field::{Mersenne31Field, MERSENNE_31_PRIME_FIELD_ORDER},
     },
-    traits::IsField,
 };
 
 #[cfg(feature = "num-traits")]
@@ -185,9 +184,7 @@ impl Neg for QM31 {
 
 #[cfg(test)]
 mod test {
-    use lambdaworks_math::field::fields::mersenne31::{
-        extensions::Degree4ExtensionField, field::MERSENNE_31_PRIME_FIELD_ORDER,
-    };
+    use lambdaworks_math::field::fields::mersenne31::field::MERSENNE_31_PRIME_FIELD_ORDER;
     use num_bigint::BigInt;
 
     use crate::{

--- a/crates/starknet-types-core/src/qm31/mod.rs
+++ b/crates/starknet-types-core/src/qm31/mod.rs
@@ -48,7 +48,7 @@ impl std::fmt::Display for InvalidQM31Packing {
 impl QM31 {
     /// Creates a QM31 from four M31 elements.
     pub fn from_coefficients(a: u32, b: u32, c: u32, d: u32) -> Self {
-        Self(const_from_coefficients(a, b, c, d))
+        Self(const_fp4e_from_coefficients(a, b, c, d))
     }
 
     /// Extracts M31 elements from a QM31.
@@ -115,7 +115,7 @@ impl QM31 {
             }
         }
 
-        Ok(Self(const_from_coefficients(
+        Ok(Self(const_fp4e_from_coefficients(
             c1 as u32, c2 as u32, c3 as u32, c4 as u32,
         )))
     }
@@ -176,7 +176,7 @@ impl Neg for QM31 {
     }
 }
 
-const fn const_from_coefficients(a: u32, b: u32, c: u32, d: u32) -> Fp4E {
+const fn const_fp4e_from_coefficients(a: u32, b: u32, c: u32, d: u32) -> Fp4E {
     Fp4E::const_from_raw([
         Fp2E::const_from_raw([FpE::const_from_raw(a), FpE::const_from_raw(b)]),
         Fp2E::const_from_raw([FpE::const_from_raw(c), FpE::const_from_raw(d)]),
@@ -190,7 +190,7 @@ mod test {
 
     use crate::{
         felt::Felt,
-        qm31::{const_from_coefficients, QM31},
+        qm31::{const_fp4e_from_coefficients, QM31},
     };
 
     #[test]
@@ -206,7 +206,7 @@ mod test {
         ];
 
         for [c1, c2, c3, c4] in cases {
-            let qm31 = QM31(const_from_coefficients(
+            let qm31 = QM31(const_fp4e_from_coefficients(
                 c1 as u32, c2 as u32, c3 as u32, c4 as u32,
             ));
             let packed_qm31 = qm31.pack_into_felt();
@@ -229,7 +229,7 @@ mod test {
         ];
 
         for [c1, c2, c3, c4] in cases {
-            let qm31 = QM31(const_from_coefficients(
+            let qm31 = QM31(const_fp4e_from_coefficients(
                 c1 as u32, c2 as u32, c3 as u32, c4 as u32,
             ));
             let packed_qm31 = qm31.pack_into_felt();

--- a/crates/starknet-types-core/src/qm31/mod.rs
+++ b/crates/starknet-types-core/src/qm31/mod.rs
@@ -48,10 +48,7 @@ impl std::fmt::Display for InvalidQM31Packing {
 impl QM31 {
     /// Creates a QM31 from four M31 elements.
     pub fn from_coefficients(a: u32, b: u32, c: u32, d: u32) -> Self {
-        Self(Fp4E::const_from_raw([
-            Fp2E::const_from_raw([FpE::const_from_raw(a), FpE::const_from_raw(b)]),
-            Fp2E::const_from_raw([FpE::const_from_raw(c), FpE::const_from_raw(d)]),
-        ]))
+        Self(const_from_coefficients(a, b, c, d))
     }
 
     /// Extracts M31 elements from a QM31.
@@ -118,16 +115,9 @@ impl QM31 {
             }
         }
 
-        Ok(Self(Fp4E::const_from_raw([
-            Fp2E::const_from_raw([
-                FpE::const_from_raw(c1 as u32),
-                FpE::const_from_raw(c2 as u32),
-            ]),
-            Fp2E::const_from_raw([
-                FpE::const_from_raw(c3 as u32),
-                FpE::const_from_raw(c4 as u32),
-            ]),
-        ])))
+        Ok(Self(const_from_coefficients(
+            c1 as u32, c2 as u32, c3 as u32, c4 as u32,
+        )))
     }
 
     /// Multiplicative inverse inside field.
@@ -186,6 +176,13 @@ impl Neg for QM31 {
     }
 }
 
+const fn const_from_coefficients(a: u32, b: u32, c: u32, d: u32) -> Fp4E {
+    Fp4E::const_from_raw([
+        Fp2E::const_from_raw([FpE::const_from_raw(a), FpE::const_from_raw(b)]),
+        Fp2E::const_from_raw([FpE::const_from_raw(c), FpE::const_from_raw(d)]),
+    ])
+}
+
 #[cfg(test)]
 mod test {
     use lambdaworks_math::field::fields::mersenne31::field::MERSENNE_31_PRIME_FIELD_ORDER;
@@ -193,7 +190,7 @@ mod test {
 
     use crate::{
         felt::Felt,
-        qm31::{Fp2E, Fp4E, FpE, QM31},
+        qm31::{const_from_coefficients, QM31},
     };
 
     #[test]
@@ -209,16 +206,9 @@ mod test {
         ];
 
         for [c1, c2, c3, c4] in cases {
-            let qm31 = QM31(Fp4E::const_from_raw([
-                Fp2E::const_from_raw([
-                    FpE::const_from_raw(c1 as u32),
-                    FpE::const_from_raw(c2 as u32),
-                ]),
-                Fp2E::const_from_raw([
-                    FpE::const_from_raw(c3 as u32),
-                    FpE::const_from_raw(c4 as u32),
-                ]),
-            ]));
+            let qm31 = QM31(const_from_coefficients(
+                c1 as u32, c2 as u32, c3 as u32, c4 as u32,
+            ));
             let packed_qm31 = qm31.pack_into_felt();
             let unpacked_qm31 = QM31::unpack_from_felt(&packed_qm31).unwrap();
 
@@ -239,16 +229,9 @@ mod test {
         ];
 
         for [c1, c2, c3, c4] in cases {
-            let qm31 = QM31(Fp4E::const_from_raw([
-                Fp2E::const_from_raw([
-                    FpE::const_from_raw(c1 as u32),
-                    FpE::const_from_raw(c2 as u32),
-                ]),
-                Fp2E::const_from_raw([
-                    FpE::const_from_raw(c3 as u32),
-                    FpE::const_from_raw(c4 as u32),
-                ]),
-            ]));
+            let qm31 = QM31(const_from_coefficients(
+                c1 as u32, c2 as u32, c3 as u32, c4 as u32,
+            ));
             let packed_qm31 = qm31.pack_into_felt();
 
             let expected_packing = BigInt::from(c1)

--- a/crates/starknet-types-core/src/qm31/mod.rs
+++ b/crates/starknet-types-core/src/qm31/mod.rs
@@ -161,6 +161,10 @@ impl Div for QM31 {
     type Output = Result<QM31, FieldError>;
 
     fn div(self, rhs: Self) -> Self::Output {
+        // While this function returns a `Result` it will always return the `Ok` variant.
+        // v0.3.0 bumped lambdaworks from 0.10.0 to 0.12.0 but v0.3.1 downgraded it to 0.11.0
+        // so the idea is to preserve the API.
+        // This function should be simplified before releasing a major version (i.e. 0.4.0)
         Ok(Self(self.0.div(rhs.0)))
     }
 }


### PR DESCRIPTION
Downgrades Lambdaworks version from 0.12.0 to 0.11.0 since both supports QM31 but the latter doesn't check that a point is in the curve when creating it.

# Pull Request type

Performance improvement.

## What is the current behavior?

Run:

```
cd starknet-types-core
make bench
```

Here are the results of Pedersen benchmarks, tested in Apple M3 Pro, macOS Sequoia 15.6.1, 18 GB RAM:

**rev `5774f89bccf6b5ed772072244ad2a17e604ada55` (base)**:

```
Pedersen/hash           time:   [19.395 µs 19.422 µs 19.451 µs]
Pedersen/hash_array/10  time:   [283.07 µs 284.58 µs 285.99 µs]
Pedersen/hash_array/100 time:   [2.7103 ms 2.7125 ms 2.7147 ms]
Pedersen/hash_array/1000 time:   [28.886 ms 28.911 ms 28.937 ms]
Pedersen/hash_array/10000 time:   [272.86 ms 273.57 ms 274.50 ms]
```

**rev `ee5743bfc1a91638150029b615fa21fdb6a3292e` (head)**:

```
Pedersen/hash           time:   [9.0100 µs 9.1308 µs 9.3493 µs]
                        change: [-53.086% -52.651% -52.039%] (p = 0.00 < 0.05)

Pedersen/hash_array/10  time:   [126.93 µs 128.00 µs 129.15 µs]
                        change: [-55.279% -55.011% -54.768%] (p = 0.00 < 0.05)

Pedersen/hash_array/100 time:   [1.2037 ms 1.2217 ms 1.2464 ms]
                        change: [-55.655% -55.338% -54.937%] (p = 0.00 < 0.05)

Pedersen/hash_array/1000
                        time:   [12.444 ms 12.573 ms 12.739 ms]
                        change: [-56.930% -56.513% -55.941%] (p = 0.00 < 0.05)

Pedersen/hash_array/10000
                        time:   [126.63 ms 127.31 ms 128.07 ms]
                        change: [-53.750% -53.464% -53.172%] (p = 0.00 < 0.05)
```

Resolves: #NA

## What is the new behavior?

0.3.0 showed a performance regression in Pedersen, making them ~120% slower. This PR restores Pedersen performance by downgrading Lambdaworks version.

At the moment, I preserved the QM31 API to avoid merging a breaking change. For instance, [this function](https://github.com/starknet-io/types-rs/blob/ee5743bfc1a91638150029b615fa21fdb6a3292e/crates/starknet-types-core/src/curve/projective_point.rs#L19-L21) returns a `Result` but it will always return the `Ok` variant. However, I'm open for suggestions to change the API for simplification.

## Does this introduce a breaking change?

No
