### PR TITLE
chore(felt): rename from_hex_unchecked to from_hex_unwrap

### DIFF
--- a/crates/starknet-types-core/src/curve/affine_point.rs
+++ b/crates/starknet-types-core/src/curve/affine_point.rs
@@ -115,16 +115,16 @@ mod test {
     #[test]
     fn affine_point_new_unchecked() {
         let a = AffinePoint::new(
-            Felt::from_hex_unchecked("0x2d39148a92f479fb077389d"),
-            Felt::from_hex_unchecked(
+            Felt::from_hex_unwrap("0x2d39148a92f479fb077389d"),
+            Felt::from_hex_unwrap(
                 "0x11a2681208d7c128580162110d9e6ddb0bd34e42ace22dcc7f52f9939e11df6",
             ),
         )
         .unwrap();
 
         let b = AffinePoint::new_unchecked(
-            Felt::from_hex_unchecked("0x2d39148a92f479fb077389d"),
-            Felt::from_hex_unchecked(
+            Felt::from_hex_unwrap("0x2d39148a92f479fb077389d"),
+            Felt::from_hex_unwrap(
                 "0x11a2681208d7c128580162110d9e6ddb0bd34e42ace22dcc7f52f9939e11df6",
             ),
         );
@@ -140,8 +140,8 @@ mod test {
         assert_eq!(identity.y(), Felt::from(1));
 
         let a = AffinePoint::new(
-            Felt::from_hex_unchecked("0x2d39148a92f479fb077389d"),
-            Felt::from_hex_unchecked(
+            Felt::from_hex_unwrap("0x2d39148a92f479fb077389d"),
+            Felt::from_hex_unwrap(
                 "0x11a2681208d7c128580162110d9e6ddb0bd34e42ace22dcc7f52f9939e11df6",
             ),
         );
@@ -152,15 +152,15 @@ mod test {
     fn affine_neg() {
         assert_eq!(
             -&AffinePoint::new(
-                Felt::from_hex_unchecked("0x2d39148a92f479fb077389d"),
-                Felt::from_hex_unchecked(
+                Felt::from_hex_unwrap("0x2d39148a92f479fb077389d"),
+                Felt::from_hex_unwrap(
                     "0x11a2681208d7c128580162110d9e6ddb0bd34e42ace22dcc7f52f9939e11df6"
                 ),
             )
             .unwrap(),
             AffinePoint::new(
-                Felt::from_hex_unchecked("0x2d39148a92f479fb077389d"),
-                Felt::from_hex_unchecked(
+                Felt::from_hex_unwrap("0x2d39148a92f479fb077389d"),
+                Felt::from_hex_unwrap(
                     "0x6e5d97edf7283fe7a7fe9deef2619224f42cb1bd531dd23380ad066c61ee20b"
                 ),
             )
@@ -172,8 +172,8 @@ mod test {
     #[test]
     fn affine_add() {
         let p = AffinePoint::new(
-            Felt::from_hex_unchecked("0x2d39148a92f479fb077389d"),
-            Felt::from_hex_unchecked(
+            Felt::from_hex_unwrap("0x2d39148a92f479fb077389d"),
+            Felt::from_hex_unwrap(
                 "0x6e5d97edf7283fe7a7fe9deef2619224f42cb1bd531dd23380ad066c61ee20b",
             ),
         )
@@ -182,10 +182,10 @@ mod test {
         assert_eq!(
             p.clone() + p,
             AffinePoint::new(
-                Felt::from_hex_unchecked(
+                Felt::from_hex_unwrap(
                     "0x23a1c9a32dd397fb1e7f758b9089757c1223057aea1d8b52cbec583ad74eaab",
                 ),
-                Felt::from_hex_unchecked(
+                Felt::from_hex_unwrap(
                     "0x466880caf4086bac129ae52ee98ddf75b2b394ae7c7ed1a19d9c61aa1f69f62",
                 ),
             )
@@ -196,8 +196,8 @@ mod test {
     #[test]
     fn affine_mul() {
         let p = AffinePoint::new(
-            Felt::from_hex_unchecked("0x2d39148a92f479fb077389d"),
-            Felt::from_hex_unchecked(
+            Felt::from_hex_unwrap("0x2d39148a92f479fb077389d"),
+            Felt::from_hex_unwrap(
                 "0x6e5d97edf7283fe7a7fe9deef2619224f42cb1bd531dd23380ad066c61ee20b",
             ),
         )
@@ -206,10 +206,10 @@ mod test {
         assert_eq!(
             &p * Felt::from(2),
             AffinePoint::new(
-                Felt::from_hex_unchecked(
+                Felt::from_hex_unwrap(
                     "0x23a1c9a32dd397fb1e7f758b9089757c1223057aea1d8b52cbec583ad74eaab",
                 ),
-                Felt::from_hex_unchecked(
+                Felt::from_hex_unwrap(
                     "0x466880caf4086bac129ae52ee98ddf75b2b394ae7c7ed1a19d9c61aa1f69f62",
                 ),
             )
@@ -220,8 +220,8 @@ mod test {
     #[test]
     fn affine_new_from_x_odd() {
         let p = AffinePoint::new(
-            Felt::from_hex_unchecked("0x2d39148a92f479fb077389d"),
-            Felt::from_hex_unchecked(
+            Felt::from_hex_unwrap("0x2d39148a92f479fb077389d"),
+            Felt::from_hex_unwrap(
                 "0x6e5d97edf7283fe7a7fe9deef2619224f42cb1bd531dd23380ad066c61ee20b",
             ),
         )
@@ -233,8 +233,8 @@ mod test {
     #[test]
     fn affine_new_from_x_even() {
         let p = AffinePoint::new(
-            Felt::from_hex_unchecked("0x2d39148a92f479fb077389d"),
-            Felt::from_hex_unchecked(
+            Felt::from_hex_unwrap("0x2d39148a92f479fb077389d"),
+            Felt::from_hex_unwrap(
                 "0x6e5d97edf7283fe7a7fe9deef2619224f42cb1bd531dd23380ad066c61ee20b",
             ),
         )

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -100,7 +100,11 @@ impl Felt {
         ))
     }
 
-    pub const fn from_hex_unwrap(val: &str) -> Self {
+    /// Create a new [Felt] from a hex static string.
+    ///
+    /// This will panic if used on incorrect values, making it unfit for parsing dynamic values.
+    /// It should only be used with static strings, idealy in tests or a `const` context.
+    pub const fn from_hex_unwrap(val: &'static str) -> Self {
         Self(FieldElement::<Stark252PrimeField>::from_hex_unchecked(val))
     }
 

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -100,6 +100,11 @@ impl Felt {
         ))
     }
 
+    pub const fn from_hex_unwrap(val: &str) -> Self {
+        Self(FieldElement::<Stark252PrimeField>::from_hex_unchecked(val))
+    }
+
+    #[deprecated(since = "0.3.1", note = "use `from_hex_unwrap` instead")]
     pub const fn from_hex_unchecked(val: &str) -> Self {
         Self(FieldElement::<Stark252PrimeField>::from_hex_unchecked(val))
     }
@@ -1141,14 +1146,14 @@ mod test {
     }
 
     #[test]
-    fn felt_from_hex_unchecked() {
-        assert_eq!(Felt::from_hex_unchecked("0"), Felt::from(0));
-        assert_eq!(Felt::from_hex_unchecked("1"), Felt::from(1));
-        assert_eq!(Felt::from_hex_unchecked("0x2"), Felt::from(2));
-        assert_eq!(Felt::from_hex_unchecked("0x0000000003"), Felt::from(3));
-        assert_eq!(Felt::from_hex_unchecked("000004"), Felt::from(4));
-        assert_eq!(Felt::from_hex_unchecked("0x05b"), Felt::from(91));
-        assert_eq!(Felt::from_hex_unchecked("A"), Felt::from(10));
+    fn felt_from_hex_unwrap() {
+        assert_eq!(Felt::from_hex_unwrap("0"), Felt::from(0));
+        assert_eq!(Felt::from_hex_unwrap("1"), Felt::from(1));
+        assert_eq!(Felt::from_hex_unwrap("0x2"), Felt::from(2));
+        assert_eq!(Felt::from_hex_unwrap("0x0000000003"), Felt::from(3));
+        assert_eq!(Felt::from_hex_unwrap("000004"), Felt::from(4));
+        assert_eq!(Felt::from_hex_unwrap("0x05b"), Felt::from(91));
+        assert_eq!(Felt::from_hex_unwrap("A"), Felt::from(10));
     }
     #[test]
     fn mul_operations() {

--- a/crates/starknet-types-core/src/felt/non_zero.rs
+++ b/crates/starknet-types-core/src/felt/non_zero.rs
@@ -150,31 +150,31 @@ mod tests {
     #[test]
     fn nonzerofelt_from_felt_unchecked() {
         assert_eq!(
-            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unchecked("9028392")),
+            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unwrap("9028392")),
             NonZeroFelt::try_from(Felt::from(0x9028392)).unwrap()
         );
         assert_eq!(
-            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unchecked("1")),
+            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unwrap("1")),
             NonZeroFelt::try_from(Felt::from(1)).unwrap()
         );
         assert_eq!(
-            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unchecked("0x2")),
+            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unwrap("0x2")),
             NonZeroFelt::try_from(Felt::from(2)).unwrap()
         );
         assert_eq!(
-            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unchecked("0x0000000003")),
+            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unwrap("0x0000000003")),
             NonZeroFelt::try_from(Felt::from(3)).unwrap()
         );
         assert_eq!(
-            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unchecked("000004")),
+            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unwrap("000004")),
             NonZeroFelt::try_from(Felt::from(4)).unwrap()
         );
         assert_eq!(
-            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unchecked("0x05b")),
+            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unwrap("0x05b")),
             NonZeroFelt::try_from(Felt::from(91)).unwrap()
         );
         assert_eq!(
-            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unchecked("A")),
+            NonZeroFelt::from_felt_unchecked(Felt::from_hex_unwrap("A")),
             NonZeroFelt::try_from(Felt::from(10)).unwrap()
         );
     }

--- a/crates/starknet-types-core/src/felt/secret_felt.rs
+++ b/crates/starknet-types-core/src/felt/secret_felt.rs
@@ -44,7 +44,7 @@ impl SecretFelt {
     /// ```
     /// use starknet_types_core::felt::{Felt, secret_felt::SecretFelt};
     ///
-    /// let mut private_key = Felt::from_hex_unchecked("0x2d39148a92f479fb077389d");
+    /// let mut private_key = Felt::from_hex_unwrap("0x2d39148a92f479fb077389d");
     /// let secret_felt = SecretFelt::from_felt(&mut private_key);
     /// // private_key is now zeroized (set to Felt::ZERO)
     /// ```
@@ -171,7 +171,7 @@ mod test {
 
     #[test]
     fn test_zeroize_original() {
-        let mut private_key = Felt::from_hex_unchecked(
+        let mut private_key = Felt::from_hex_unwrap(
             "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
         );
         let mut signing_key = SecretFelt::from_felt(&mut private_key);
@@ -210,7 +210,7 @@ mod test {
 
     #[test]
     fn test_zeroize_on_drop() {
-        let mut private_key = Felt::from_hex_unchecked(
+        let mut private_key = Felt::from_hex_unwrap(
             "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
         );
 
@@ -244,7 +244,7 @@ mod test {
 
     #[test]
     fn test_inner_value() {
-        let mut private_key = Felt::from_hex_unchecked(
+        let mut private_key = Felt::from_hex_unwrap(
             "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
         );
 

--- a/crates/starknet-types-core/src/felt/serde.rs
+++ b/crates/starknet-types-core/src/felt/serde.rs
@@ -109,15 +109,15 @@ mod tests {
         ];
         assert_tokens(&Felt::MAX.compact(), &[Token::Bytes(&MAX)]);
         assert_tokens(
-            &Felt::from_hex_unchecked("0xbabe").compact(),
+            &Felt::from_hex_unwrap("0xbabe").compact(),
             &[Token::Bytes(&[0xba, 0xbe])],
         );
         assert_tokens(
-            &Felt::from_hex_unchecked("0xba000000be").compact(),
+            &Felt::from_hex_unwrap("0xba000000be").compact(),
             &[Token::Bytes(&[0xba, 0, 0, 0, 0xbe])],
         );
         assert_tokens(
-            &Felt::from_hex_unchecked("0xbabe0000").compact(),
+            &Felt::from_hex_unwrap("0xbabe0000").compact(),
             &[Token::Bytes(&[0xba, 0xbe, 0, 0])],
         );
     }

--- a/crates/starknet-types-core/src/hash/blake2s.rs
+++ b/crates/starknet-types-core/src/hash/blake2s.rs
@@ -49,7 +49,7 @@ impl Blake2Felt252 {
     /// Values below `SMALL_THRESHOLD` are encoded as two `u32`s,
     /// while values at or above it are encoded as eight `u32`s
     /// (`SMALL_THRESHOLD` equals `2**63`).
-    pub const SMALL_THRESHOLD: Felt = Felt::from_hex_unchecked("8000000000000000");
+    pub const SMALL_THRESHOLD: Felt = Felt::from_hex_unwrap("8000000000000000");
 
     /// Encodes each `Felt` into 32-bit words:
     /// - **Small** values `< 2^63` get **2** words: `[ high_32_bits, low_32_bits ]` from the last 8
@@ -138,7 +138,7 @@ mod tests {
     fn test_encode_felts_to_u32s_small() {
         // Last 8 bytes of 0x1122334455667788 in big-endian are [0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88].
         // High word = 0x11223344, low word = 0x55667788.
-        let val = Felt::from_hex_unchecked("1122334455667788");
+        let val = Felt::from_hex_unwrap("1122334455667788");
         let words = Blake2Felt252::encode_felts_to_u32s(&[val]);
         assert_eq!(words, vec![0x11223344, 0x55667788]);
     }
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn test_encode_felts_to_u32s_big() {
         // The value 2^63 (0x8000000000000000) triggers the "big" path.
-        let val = Felt::from_hex_unchecked("8000000000000000");
+        let val = Felt::from_hex_unwrap("8000000000000000");
         let words = Blake2Felt252::encode_felts_to_u32s(&[val]);
 
         // Expected limbs: split full 32-byte BE into eight 32-bit words.
@@ -209,9 +209,9 @@ mod tests {
     /// Test that hashing a single zero Felt produces the expected 256-bit Blake2s digest.
     #[test]
     fn test_hash_single_zero() {
-        let zero = Felt::from_hex_unchecked("0");
+        let zero = Felt::from_hex_unwrap("0");
         let hash = Blake2Felt252::hash_single(&zero);
-        let expected = Felt::from_hex_unchecked(
+        let expected = Felt::from_hex_unwrap(
             "5768af071a2f8df7c9df9dc4ca0e7a1c5908d5eff88af963c3264f412dbdf43",
         );
         assert_eq!(hash, expected);
@@ -220,10 +220,10 @@ mod tests {
     /// Test that hashing an array of Felts [1, 2] produces the expected 256-bit Blake2s digest.
     #[test]
     fn test_hash_array_one_two() {
-        let one = Felt::from_hex_unchecked("1");
-        let two = Felt::from_hex_unchecked("2");
+        let one = Felt::from_hex_unwrap("1");
+        let two = Felt::from_hex_unwrap("2");
         let hash = Blake2Felt252::hash_array(&[one, two]);
-        let expected = Felt::from_hex_unchecked(
+        let expected = Felt::from_hex_unwrap(
             "5534c03a14b214436366f30e9c77b6e56c8835de7dc5aee36957d4384cce66d",
         );
         assert_eq!(hash, expected);
@@ -235,7 +235,7 @@ mod tests {
     #[case::empty(vec![], "874258848688468311465623299960361657518391155660316941922502367727700287818")]
     #[case::boundary_under_2_63(vec![Felt::from((1u64 << 63) - 1)], "94160078030592802631039216199460125121854007413180444742120780261703604445")]
     #[case::boundary_at_2_63(vec![Felt::from(1u64 << 63)], "318549634615606806810268830802792194529205864650702991817600345489579978482")]
-    #[case::very_large_felt(vec![Felt::from_hex_unchecked("800000000000011000000000000000000000000000000000000000000000000")], "3505594194634492896230805823524239179921427575619914728883524629460058657521")]
+    #[case::very_large_felt(vec![Felt::from_hex_unwrap("800000000000011000000000000000000000000000000000000000000000000")], "3505594194634492896230805823524239179921427575619914728883524629460058657521")]
     #[case::mixed_small_large(vec![Felt::from(42), Felt::from(1u64 << 63), Felt::from(1337)], "1127477916086913892828040583976438888091205536601278656613505514972451246501")]
     #[case::max_u64(vec![Felt::from(u64::MAX)], "3515074221976790747383295076946184515593027667350620348239642126105984996390")]
     fn test_encode_felt252_data_and_calc_blake_hash(

--- a/crates/starknet-types-core/src/short_string/mod.rs
+++ b/crates/starknet-types-core/src/short_string/mod.rs
@@ -124,10 +124,10 @@ mod tests {
     fn ok() {
         for (string, expected_felt) in [
             (String::default(), Felt::ZERO),
-            (String::from("aa"), Felt::from_hex_unchecked("0x6161")),
+            (String::from("aa"), Felt::from_hex_unwrap("0x6161")),
             (
                 String::from("approve"),
-                Felt::from_hex_unchecked("0x617070726f7665"),
+                Felt::from_hex_unwrap("0x617070726f7665"),
             ),
             (
                 String::from("SN_SEPOLIA"),

--- a/fuzz/felt/fuzz_targets/conversions.rs
+++ b/fuzz/felt/fuzz_targets/conversions.rs
@@ -40,9 +40,9 @@ fuzz_target!(|felt: Felt| {
         assert_eq!(felt_as_bits[i], bit);
     }
 
-    // to_hex_string, to_fixed_hex_string, from_hex_unchecked
-    assert_eq!(felt, Felt::from_hex_unchecked(&felt.to_hex_string()));
-    assert_eq!(felt, Felt::from_hex_unchecked(&felt.to_fixed_hex_string()));
+    // to_hex_string, to_fixed_hex_string, from_hex_unwrap
+    assert_eq!(felt, Felt::from_hex_unwrap(&felt.to_hex_string()));
+    assert_eq!(felt, Felt::from_hex_unwrap(&felt.to_fixed_hex_string()));
     assert_eq!(66, felt.to_fixed_hex_string().len());
 
     // from_dec_str


### PR DESCRIPTION
`from_hex_unchecked` is badly named.
It actually checks the felt value and will panic if it is too big.
So `from_hex_unwrap` is a better name.

This PR deprecates `from_hex_unchecked` and introduces the new `from_hex_unwrap`, allowing for a non-breaking, smooth transition downstream.