### PR TITLE
aviv@ubu-avivyo-lt ~/Workspace/types-rs (main) gke_starkware-dev_us-west1_sequencer-dev-2  $git switch -c aviv/make_blake_utils_pub origin/main branch 'aviv/make_blake_utils_pub' set up to track 'origin/main'. Switched to a new branch 'aviv/make_blake_utils_pub' aviv@ubu-avivyo-lt ~/Workspace/types-rs (aviv/make_blake_utils_pub) gke_starkware-dev_us-west1_sequencer-dev-2  $git push -u origin aviv/make_blake_utils_pub Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0) remote:  remote: Create a pull request for 'aviv/make_blake_utils_pub' on GitHub by visiting: remote:      https://github.com/starknet-io/types-rs/pull/new/aviv/make_blake_utils_pub remote:  To github.com:starknet-io/types-rs.git  * [new branch]      aviv/make_blake_utils_pub -> aviv/make_blake_utils_pub branch 'aviv/make_blake_utils_pub' set up to track 'origin/aviv/make_blake_utils_pub'. aviv@ubu-avivyo-lt ~/Workspace/types-rs (aviv/make_blake_utils_pub) gke_starkware-dev_us-west1_sequencer-dev-2  $

### DIFF
--- a/crates/starknet-types-core/src/hash/blake2s.rs
+++ b/crates/starknet-types-core/src/hash/blake2s.rs
@@ -90,7 +90,7 @@ impl Blake2Felt252 {
 
     /// Packs the first 8 little-endian 32-bit words (32 bytes) of `bytes`
     /// into a single 252-bit Felt.
-    fn pack_256_le_to_felt(bytes: &[u8]) -> Felt {
+    pub fn pack_256_le_to_felt(bytes: &[u8]) -> Felt {
         assert!(bytes.len() >= 32, "need at least 32 bytes to pack 8 words");
 
         // 1) copy your 32-byte LE-hash into the low 32 bytes of a 32-byte buffer.
@@ -101,7 +101,7 @@ impl Blake2Felt252 {
         Felt::from_bytes_le(&buf)
     }
 
-    fn blake2s_to_felt(data: &[u8]) -> Felt {
+    pub fn blake2s_to_felt(data: &[u8]) -> Felt {
         let mut hasher = Blake2s256::new();
         hasher.update(data);
         let hash32 = hasher.finalize();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

refactor: make blake utils pub

## What is the current behavior?

Some utils are private

Resolves: #NA

## What is the new behavior?

All the utils are pub

## Does this introduce a breaking change?

No

## Other information