### PR TITLE
[v0.2] Bump Lambdaworks to 0.13.0

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -11,7 +11,7 @@ description = "Core types representation for Starknet"
 readme = "README.md"
 
 [dependencies]
-lambdaworks-math = { version = "0.12.0", default-features = false }
+lambdaworks-math = { version = "0.13.0", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
 num-integer = { version = "0.1", default-features = false }
@@ -23,7 +23,7 @@ digest = { version = "0.10.7", optional = true }
 serde = { version = "1", optional = true, default-features = false, features = [
     "alloc", "derive"
 ] }
-lambdaworks-crypto = { version = "0.12.0", default-features = false, optional = true }
+lambdaworks-crypto = { version = "0.13.0", default-features = false, optional = true }
 parity-scale-codec = { version = "3.6", default-features = false, optional = true }
 lazy_static = { version = "1.5", default-features = false, optional = true }
 zeroize = { version = "1.8.1", default-features = false, optional = true }

--- a/crates/starknet-types-core/src/curve/affine_point.rs
+++ b/crates/starknet-types-core/src/curve/affine_point.rs
@@ -2,7 +2,6 @@ use crate::{curve::curve_errors::CurveError, felt::Felt};
 use lambdaworks_math::{
     cyclic_group::IsGroup,
     elliptic_curve::{
-        point::ProjectivePoint,
         short_weierstrass::{
             curves::stark_curve::StarkCurve, point::ShortWeierstrassProjectivePoint,
             traits::IsShortWeierstrass,
@@ -28,11 +27,11 @@ impl AffinePoint {
     /// This method should be used with caution, as it does not validate whether the provided coordinates
     /// correspond to a valid point on the curve.
     pub const fn new_unchecked(x: Felt, y: Felt) -> AffinePoint {
-        Self(ShortWeierstrassProjectivePoint(ProjectivePoint::new([
+        Self(ShortWeierstrassProjectivePoint::new_unchecked([
             x.0,
             y.0,
             Felt::ONE.0,
-        ])))
+        ]))
     }
 
     /// Construct new affine point from the `x` coordinate and the parity bit `y_parity`.

--- a/crates/starknet-types-core/src/curve/projective_point.rs
+++ b/crates/starknet-types-core/src/curve/projective_point.rs
@@ -3,7 +3,6 @@ use crate::curve::curve_errors::CurveError;
 use crate::felt::Felt;
 use core::ops;
 use lambdaworks_math::cyclic_group::IsGroup;
-use lambdaworks_math::elliptic_curve::point::ProjectivePoint as LambdaworksProjectivePoint;
 use lambdaworks_math::elliptic_curve::short_weierstrass::curves::stark_curve::StarkCurve;
 use lambdaworks_math::elliptic_curve::short_weierstrass::point::ShortWeierstrassProjectivePoint;
 use lambdaworks_math::elliptic_curve::traits::EllipticCurveError::InvalidPoint;
@@ -30,9 +29,9 @@ impl ProjectivePoint {
     /// SAFETY: Failing to guarantee this assumptions could lead to a runtime panic
     /// while operating with the value.
     pub const fn new_unchecked(x: Felt, y: Felt, z: Felt) -> ProjectivePoint {
-        Self(ShortWeierstrassProjectivePoint(
-            LambdaworksProjectivePoint::new([x.0, y.0, z.0]),
-        ))
+        Self(ShortWeierstrassProjectivePoint::new_unchecked([
+            x.0, y.0, z.0,
+        ]))
     }
 
     /// The point at infinity.
@@ -65,9 +64,11 @@ impl ProjectivePoint {
     /// This method should be used with caution, as it does not validate whether the provided coordinates
     /// correspond to a valid point on the curve.
     pub fn from_affine_unchecked(x: Felt, y: Felt) -> Self {
-        Self(ShortWeierstrassProjectivePoint(
-            LambdaworksProjectivePoint::new([x.0, y.0, Felt::ONE.0]),
-        ))
+        Self(ShortWeierstrassProjectivePoint::new_unchecked([
+            x.0,
+            y.0,
+            Felt::ONE.0,
+        ]))
     }
 
     /// Returns the `x` coordinate of the point.

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -61,6 +61,7 @@ impl core::fmt::Display for FromStrError {
             CreationError::InvalidHexString => write!(f, "invalid hex string"),
             CreationError::InvalidDecString => write!(f, "invalid dec string"),
             CreationError::HexStringIsTooBig => write!(f, "hex string too big"),
+            CreationError::RepresentativeOutOfRange => write!(f, "representative out of range"),
             CreationError::EmptyString => write!(f, "empty string"),
         }
     }

--- a/ensure_no_std/rust-toolchain.toml
+++ b/ensure_no_std/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.87.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.87.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
Clone of #166 but it targets v0.2 instead of v0.3.

**NOTE:** This is breaking since this PR changes minimum Rust version from 1.84.1 to 1.87.0.