### PR TITLE
Restore sizeof and bump patch version to 0.2.3

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-types-core"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/starknet-io/types-rs"
@@ -15,6 +15,7 @@ lambdaworks-math = { version = "0.13.0", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
 num-integer = { version = "0.1", default-features = false }
+size-of = { version = "0.1.5", default-features = false }
 
 # Optional
 arbitrary = { version = "1.3", optional = true }

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -34,6 +34,7 @@ use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
 use num_traits::{One, Zero};
 pub use primitive_conversions::PrimitiveFromFeltError;
+use size_of::SizeOf;
 
 use lambdaworks_math::{
     field::{
@@ -47,6 +48,10 @@ use lambdaworks_math::{
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Felt(pub(crate) FieldElement<Stark252PrimeField>);
+
+impl SizeOf for Felt {
+    fn size_of_children(&self, _context: &mut size_of::Context) {}
+}
 
 #[derive(Debug)]
 pub struct FromStrError(CreationError);
@@ -769,6 +774,7 @@ mod test {
     use num_traits::Num;
     use proptest::prelude::*;
     use regex::Regex;
+    use size_of::TotalSize;
 
     #[test]
     fn test_debug_format() {
@@ -1329,5 +1335,16 @@ mod test {
         let one: Felt = true.into();
         assert_eq!(one, Felt::ONE);
         assert_eq!(zero, Felt::ZERO);
+    }
+
+    #[test]
+    fn felt_size_of() {
+        assert_eq!(Felt::ZERO.size_of(), TotalSize::total(32));
+        assert_eq!(Felt::ONE.size_of(), TotalSize::total(32));
+        assert_eq!(
+            Felt(FieldElement::from(1600000000)).size_of(),
+            TotalSize::total(32)
+        );
+        assert_eq!(Felt::MAX.size_of(), TotalSize::total(32));
     }
 }


### PR DESCRIPTION
Patch: restore `SizeOf` for `Felt` (temporarily)

- Feature
- Other: bump patch version

## What is the current behavior?

No implementation of `size_of::SizeOf` on Felt since https://github.com/starknet-io/types-rs/pull/158; revert this change to publish v0.2.3, and then revert and publish 0.2.4

Resolves: lack of `SizeOf` impl

## What is the new behavior?

- Implementation of `SizeOf` for `Felt` is restored
- Crate patch version is bumped

## Does this introduce a breaking change?

Will break conflicting implementations of a `SizeOf` trait, if they exist
